### PR TITLE
Changes for MSVC compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ xcuserdata/
 /build/
 DerivedData/
 1000people.fleece
+Debug/

--- a/Fleece/Array.cc
+++ b/Fleece/Array.cc
@@ -172,10 +172,19 @@ namespace fleece {
             return key ? deref(next(key)) : NULL;
         }
 
+#ifdef _MSC_VER
+#if 1
+        // NOTE: Can't get this to compile
+#define log(FMT, PARAM, ...)
+#else
+#define log(FMT, PARAM, ...) ({for (unsigned i_=0; i_<indent; i_++) std::cerr << "\t"; fprintf(stderr, FMT "\n", PARAM, __VA_ARGS__);})
+#endif
+#else
 #ifdef NDEBUG
 #define log(FMT, PARAM...) ({})
 #else
 #define log(FMT, PARAM...) ({for (unsigned i_=0; i_<indent; i_++) std::cerr << "\t"; fprintf(stderr, FMT "\n", PARAM);})
+#endif
 #endif
 
         size_t get(Dict::key keysToFind[], const Value* values[], size_t nKeys) {

--- a/Fleece/Encoder.cc
+++ b/Fleece/Encoder.cc
@@ -22,6 +22,12 @@
 #include <math.h>
 #include <stdlib.h>
 
+#ifdef _MSC_VER
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#define __builtin_expect
+#endif
+
 
 namespace fleece {
 
@@ -379,12 +385,12 @@ namespace fleece {
             if (items->wide) {
                 _out.write(&(*items)[0], kWide*nValues);
             } else {
-                uint16_t narrow[nValues];
+                std::vector<uint16_t> narrow(nValues);
                 size_t i = 0;
                 for (auto v = items->begin(); v != items->end(); ++v, ++i) {
                     ::memcpy(&narrow[i], &*v, kNarrow);
                 }
-                _out.write(narrow, kNarrow*nValues);
+                _out.write(narrow.data(), kNarrow*nValues);
             }
         }
 
@@ -420,11 +426,11 @@ namespace fleece {
                 keys[i].buf = offsetby(&items[2*i], 1);
 
         // Construct an array that describes the permutation of item indices:
-        const slice* indices[n];
+        std::vector<const slice*> indices(n);
         const slice* base = &keys[0];
         for (unsigned i = 0; i < n; i++)
             indices[i] = base + i;
-        ::qsort(indices, n, sizeof(indices[0]), &compareKeysByIndex);
+        ::qsort(indices.data(), n, sizeof(indices[0]), &compareKeysByIndex);
         // indices[i] is now a pointer to the Value that should go at index i
 
         // Now rewrite items according to the permutation in indices:

--- a/Fleece/KeyTree.cc
+++ b/Fleece/KeyTree.cc
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <math.h>
 #include <iostream>
+#include <algorithm>
 
 
 namespace fleece {

--- a/Fleece/StringTable.cc
+++ b/Fleece/StringTable.cc
@@ -17,6 +17,9 @@
 #include <algorithm>
 #include <assert.h>
 #include <stdlib.h>
+#if _MSC_VER
+#define __builtin_expect
+#endif
 
 namespace fleece {
 

--- a/Fleece/Value.cc
+++ b/Fleece/Value.cc
@@ -47,7 +47,8 @@ namespace fleece {
         auto t = tag();
         if (t == kSpecialTag) {
             switch (tinyValue()) {
-                case kSpecialValueFalse...kSpecialValueTrue:
+                case kSpecialValueFalse:
+                case kSpecialValueTrue:
                     return kBoolean;
                 case kSpecialValueNull:
                 default:
@@ -63,7 +64,9 @@ namespace fleece {
         switch (tag()) {
             case kSpecialTag:
                 return tinyValue() == kSpecialValueTrue;
-            case kShortIntTag...kFloatTag:
+            case kShortIntTag:
+            case kIntTag:
+            case kFloatTag:
                 return asInt() != 0;
             default:
                 return true;

--- a/Fleece/Value.hh
+++ b/Fleece/Value.hh
@@ -22,6 +22,8 @@
 #include <map>
 #ifdef __OBJC__
 #import <Foundation/NSMapTable.h>
+#elif defined(_MSC_VER)
+#define __builtin_expect
 #endif
 
 

--- a/Fleece/Writer.cc
+++ b/Fleece/Writer.cc
@@ -17,6 +17,7 @@
 #include "decode.h"
 #include "encode.h"
 #include <assert.h>
+#include <algorithm>
 
 
 namespace fleece {
@@ -164,9 +165,9 @@ namespace fleece {
 
     void Writer::writeDecodedBase64(slice base64) {
         base64::decoder dec;
-        char buf[(base64.size + 3) / 4 * 3];
-        size_t len = dec.decode(base64.buf, base64.size, buf);
-        write(buf, len);
+        std::vector<char> buf((base64.size + 3) / 4 * 3);
+        size_t len = dec.decode(base64.buf, base64.size, buf.data());
+        write(buf.data(), len);
     }
 
 }

--- a/Fleece/slice.cc
+++ b/Fleece/slice.cc
@@ -24,10 +24,14 @@ namespace fleece {
         // Optimized for speed
         if (this->size == b.size)
             return memcmp(this->buf, b.buf, this->size);
-        else if (this->size < b.size)
-            return memcmp(this->buf, b.buf, this->size) ?: -1;
-        else
-            return memcmp(this->buf, b.buf, b.size) ?: 1;
+        else if (this->size < b.size) {
+            int result = memcmp(this->buf, b.buf, this->size);
+            return result ? result : -1;
+        }
+        else {
+            int result = memcmp(this->buf, b.buf, b.size);
+            return result ? result : -1;
+        }
     }
 
     slice slice::read(size_t nBytes) {

--- a/MSVC/Fleece/Fleece.vcxproj
+++ b/MSVC/Fleece/Fleece.vcxproj
@@ -1,0 +1,161 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Fleece\Array.cc" />
+    <ClCompile Include="..\..\Fleece\Encoder.cc" />
+    <ClCompile Include="..\..\Fleece\FleeceException.cc" />
+    <ClCompile Include="..\..\Fleece\Fleece_C_impl.cc" />
+    <ClCompile Include="..\..\Fleece\JSONConverter.cc" />
+    <ClCompile Include="..\..\Fleece\KeyTree.cc" />
+    <ClCompile Include="..\..\Fleece\slice.cc" />
+    <ClCompile Include="..\..\Fleece\StringTable.cc" />
+    <ClCompile Include="..\..\Fleece\Value+Dump.cc" />
+    <ClCompile Include="..\..\Fleece\Value+JSON.cc" />
+    <ClCompile Include="..\..\Fleece\Value.cc" />
+    <ClCompile Include="..\..\Fleece\varint.cc" />
+    <ClCompile Include="..\..\Fleece\Writer.cc" />
+    <ClCompile Include="..\..\vendor\jsonsl\jsonsl.c" />
+    <ClCompile Include="..\..\vendor\libb64\cdecode.c" />
+    <ClCompile Include="..\..\vendor\libb64\cencode.c" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{D881259A-20AF-4261-92B1-24F622B7D2F4}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>Fleece</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IncludePath>$(ProjectDir)..\..\vendor\libb64;$(ProjectDir)..\..\vendor\jsonsl;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IncludePath>$(ProjectDir)..\..\vendor\libb64;$(ProjectDir)..\..\vendor\jsonsl;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IncludePath>$(ProjectDir)..\..\vendor\libb64;$(ProjectDir)..\..\vendor\jsonsl;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IncludePath>$(ProjectDir)..\..\vendor\libb64;$(ProjectDir)..\..\vendor\jsonsl;$(IncludePath)</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/MSVC/Fleece/Fleece.vcxproj.filters
+++ b/MSVC/Fleece/Fleece.vcxproj.filters
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\Fleece\Array.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\Encoder.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\Fleece_C_impl.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\FleeceException.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\JSONConverter.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\KeyTree.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\slice.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\StringTable.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\Value.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\Value+Dump.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\Value+JSON.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\varint.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Fleece\Writer.cc">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\vendor\libb64\cdecode.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\vendor\libb64\cencode.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\vendor\jsonsl\jsonsl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/vendor/libb64/cdecode.c
+++ b/vendor/libb64/cdecode.c
@@ -20,7 +20,7 @@ void base64_init_decodestate(base64_decodestate* state_in)
 	state_in->plainchar = 0;
 }
 
-size_t base64_decode_block(const void* code_in, const size_t length_in, void* plaintext_out,
+size_t base64_decode_block(const uint8_t* code_in, const size_t length_in, void* plaintext_out,
 						   base64_decodestate* state_in)
 {
 	const uint8_t* codechar = code_in;

--- a/vendor/libb64/cdecode.h
+++ b/vendor/libb64/cdecode.h
@@ -7,7 +7,7 @@ For details, see http://sourceforge.net/projects/libb64
 
 #ifndef BASE64_CDECODE_H
 #define BASE64_CDECODE_H
-#include <stddef.h>
+#include <stdint.h>
 
 typedef enum
 {

--- a/vendor/libb64/cencode.c
+++ b/vendor/libb64/cencode.c
@@ -24,7 +24,7 @@ char base64_encode_value(uint8_t value_in)
 	return encoding[(int)value_in];
 }
 
-size_t base64_encode_block(const void* plaintext_in, size_t length_in, void* code_out,
+size_t base64_encode_block(const uint8_t* plaintext_in, size_t length_in, void* code_out,
 						   base64_encodestate* state_in)
 {
 	const uint8_t* plainchar = plaintext_in;

--- a/vendor/libb64/cencode.h
+++ b/vendor/libb64/cencode.h
@@ -7,7 +7,7 @@ For details, see http://sourceforge.net/projects/libb64
 
 #ifndef BASE64_CENCODE_H
 #define BASE64_CENCODE_H
-#include <stddef.h>
+#include <stdint.h>
 
 typedef enum
 {


### PR DESCRIPTION
Note the Array.cc issue.  I can't figure out what is wrong with it.  

The libb64 stuff is because MSVC doesn't allow pointer math on void pointers.

Need to confirm that using vectors and then passing their `data()` is a valid thing to do.