### PR TITLE
unsigned long and uint64_t are identical

### DIFF
--- a/Fleece/Encoder.hh
+++ b/Fleece/Encoder.hh
@@ -118,9 +118,8 @@ namespace fleece {
         // Note: overriding <<(bool) would be dangerous due to implicit conversion
         Encoder& operator<< (int64_t i)         {writeInt(i); return *this;}
         Encoder& operator<< (uint64_t i)        {writeUInt(i); return *this;}
-        Encoder& operator<< (int i)             {writeInt(i); return *this;}
-        Encoder& operator<< (unsigned i)        {writeUInt(i); return *this;}
-        Encoder& operator<< (unsigned long i)   {writeUInt(i); return *this;}
+        Encoder& operator<< (int32_t i)             {writeInt(i); return *this;}
+        Encoder& operator<< (uint32_t i)        {writeUInt(i); return *this;}
         Encoder& operator<< (double d)          {writeDouble(d); return *this;}
         Encoder& operator<< (float f)           {writeFloat(f); return *this;}
         Encoder& operator<< (const std::string &str)   {writeString(str); return *this;}


### PR DESCRIPTION
On most 64-bit Linux systems.  This is a small PR but needs a once over.