### PR TITLE
Build fleece tool with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,8 @@ endif()
 add_library(Fleece        SHARED  ${FLEECE_SRC})
 add_library(FleeceStatic  STATIC  ${FLEECE_SRC})
 
+add_executable(fleece Tool/fleece_tool.cc ${FLEECE_SRC})
+
 if (APPLE)
     target_link_libraries(Fleece  
                           "-framework CoreFoundation" 

--- a/Tool/fleece_tool.cc
+++ b/Tool/fleece_tool.cc
@@ -33,7 +33,7 @@ static alloc_slice readInput(FILE *in) {
     }
     if (ferror(in))
         throw "Error reading input";
-    return out.str();
+    return alloc_slice(out.str());
 }
 
 int main(int argc, const char * argv[]) {


### PR DESCRIPTION
For simplicity it just compiles library sources statically instead of using shared object.

Also `std:string` constructor of `alloc_slice` declared as explicit, so the tool didn't compile without the second fix. If needed I can do it separately.