### PR TITLE
Do not round up when converting from float to int number

### DIFF
--- a/Fleece/Value.cc
+++ b/Fleece/Value.cc
@@ -99,7 +99,7 @@ namespace fleece {
                 return _decLittle64(n);
             }
             case kFloatTag:
-                return (int64_t)round(asDouble());
+                return (int64_t)asDouble();
             default:
                 return 0;
         }


### PR DESCRIPTION
Removed round up so just cast.

Reference: https://github.com/couchbase/couchbase-lite-ios/issues/1764