### PR TITLE
Eliminated `machine/` path for `endian.h` due to NDK's unified header…

### DIFF
--- a/Fleece/forestdb_endian.h
+++ b/Fleece/forestdb_endian.h
@@ -21,7 +21,7 @@
     #endif
 
 #elif __ANDROID__
-    #include <machine/endian.h>
+    #include <endian.h>
     #if _BYTE_ORDER == _LITTLE_ENDIAN
         #ifndef _LITTLE_ENDIAN
         #define _LITTLE_ENDIAN


### PR DESCRIPTION
…s change.

- https://android.googlesource.com/platform/ndk/+/master/docs/UnifiedHeaders.md