### PR TITLE
Fixes a compilation failure with clang 3.8.0.

### DIFF
--- a/Fleece/Value.hh
+++ b/Fleece/Value.hh
@@ -48,7 +48,7 @@ namespace fleece {
     class Null {
     };
 
-    constexpr Null nullValue;
+    constexpr Null nullValue();
 
 
     /* An encoded data value */


### PR DESCRIPTION
Compilation fails with clang 3.8.0 on Ubuntu 16.04 like Linux without this change (observed on ElementaryOS Loki).

The error message resolved by this change:

```
/home/mz2/Projects/couchbase-lite-node/vendor/couchbase-lite-core/vendor/fleece/Fleece/Value.hh:51:20: error: default initialization of an object of const type 'const fleece::Null' without a user-provided default constructor
```