### PR TITLE
JSONDelta: Fixed issues with multibyte UTF-8 chars

### DIFF
--- a/Fleece/Core/JSONDelta.hh
+++ b/Fleece/Core/JSONDelta.hh
@@ -36,6 +36,13 @@ namespace fleece { namespace impl {
             If the delta is malformed or can't be applied to `old`, throws a FleeceException. */
         static void apply(const Value *old, const Value* NONNULL delta, Encoder&);
 
+        /** Minimum byte length of strings that will be considered for diffing (default 60) */
+        static size_t gMinStringDiffLength;
+
+        /** Maximum time (in seconds) that the string-diff algorithm is allowed to run
+            (default 0.25) */
+        static float gTextDiffTimeout;
+
     private:
         struct pathItem;
 


### PR DESCRIPTION
* If diff_match_patch returns a patch range that intersects a UTF-8
  multibyte character, the range is adjusted to fall on a character
  boundary. This prevents the generated JSON patch string from
  containing invalid UTF-8.
* Made gMinStringDiffLength and gTextDiffTimeout changeable.

Fixes #40