### PR TITLE
Add support for parsing string date parts

### DIFF
--- a/Fleece/Core/Encoder.cc
+++ b/Fleece/Core/Encoder.cc
@@ -390,7 +390,7 @@ namespace fleece { namespace impl {
 
     void Encoder::writeDateString(int64_t timestamp, bool asUTC) {
         char str[kFormattedISO8601DateMaxSize];
-        writeString(FormatISO8601Date(str, timestamp, asUTC));
+        writeString(FormatISO8601Date(str, timestamp, asUTC, nullptr));
     }
 
 

--- a/Fleece/Support/JSONEncoder.cc
+++ b/Fleece/Support/JSONEncoder.cc
@@ -67,7 +67,7 @@ namespace fleece { namespace impl {
 
     void JSONEncoder::writeDateString(int64_t timestamp, bool asUTC) {
         char str[kFormattedISO8601DateMaxSize];
-        writeString(FormatISO8601Date(str, timestamp, asUTC));
+        writeString(FormatISO8601Date(str, timestamp, asUTC, nullptr));
     }
 
 

--- a/Fleece/Support/ParseDate.hh
+++ b/Fleece/Support/ParseDate.hh
@@ -24,19 +24,22 @@ namespace fleece {
 
     static constexpr int64_t kInvalidDate = INT64_MIN;
 
+    /*
+     ** Components of a date that can be extracted, diffed, or added using date-time functions
+     */
     typedef enum {
-        kDateComponentMillennium,
-        kDateComponentCentury,
-        kDateComponentDecade,
-        kDateComponentYear,
-        kDateComponentQuarter,
-        kDateComponentMonth,
-        kDateComponentWeek,
-        kDateComponentDay,
-        kDateComponentHour,
-        kDateComponentMinute,
-        kDateComponentSecond,
-        kDateComponentMillisecond,
+        kDateComponentMillennium,  /* 1000 years */
+        kDateComponentCentury,     /* 100 years */  
+        kDateComponentDecade,      /* 10 years */  
+        kDateComponentYear,        /* 146097 / 400 days */  
+        kDateComponentQuarter,     /* 3 months */
+        kDateComponentMonth,       /* 1/12 years */  
+        kDateComponentWeek,        /* 7 days */
+        kDateComponentDay,         /* 24 hours */
+        kDateComponentHour,        /* 60 minutes */
+        kDateComponentMinute,      /* 60 seconds */
+        kDateComponentSecond,      /* 1000 milliseconds */  
+        kDateComponentMillisecond, /* base unit */
         kDateComponentInvalid
     } DateComponent;
 
@@ -56,12 +59,18 @@ namespace fleece {
         char validTZ;      /* True (1) if tz is valid */
     };
 
+    /** Parses a C string as an ISO-8601 date-time, returning a parsed DateTime struct */
     DateTime ParseISO8601DateRaw(const char* dateStr);
 
+    /** Parses a C string as an ISO-8601 date-time, returning a parsed DateTime struct */
     DateTime ParseISO8601DateRaw(slice dateStr);
 
+    /** Converts an existing DateTime struct into a timestamp (milliseconds since 
+         1/1/1970) */
     int64_t ToMillis(DateTime& dt);
 
+    /** Converts a timestamp (milliseconds since 1/1/1970) into a parsed DateTime struct
+        in UTC time */
     DateTime FromMillis(int64_t millis);
 
     /** Parses a C string as an ISO-8601 date-time, returning a timestamp (milliseconds since

--- a/Fleece/Support/ParseDate.hh
+++ b/Fleece/Support/ParseDate.hh
@@ -24,6 +24,22 @@ namespace fleece {
 
     static constexpr int64_t kInvalidDate = INT64_MIN;
 
+    typedef enum {
+        kDateComponentMillennium,
+        kDateComponentCentury,
+        kDateComponentDecade,
+        kDateComponentYear,
+        kDateComponentQuarter,
+        kDateComponentMonth,
+        kDateComponentWeek,
+        kDateComponentDay,
+        kDateComponentHour,
+        kDateComponentMinute,
+        kDateComponentSecond,
+        kDateComponentMillisecond,
+        kDateComponentInvalid
+    } DateComponent;
+
     /** Parses a C string as an ISO-8601 date-time, returning a timestamp (milliseconds since
         1/1/1970), or kInvalidDate if the string is not valid. */
     int64_t ParseISO8601Date(const char* dateStr);
@@ -31,6 +47,10 @@ namespace fleece {
     /** Parses a C string as an ISO-8601 date-time, returning a timestamp (milliseconds since
         1/1/1970), or kInvalidDate if the string is not valid. */
     int64_t ParseISO8601Date(slice dateStr);
+
+    /** Parses a C string as a date component (valid strings are represented by the DateComponent
+        enum above) */
+    DateComponent ParseDateComponent(slice component);
 
     /** Maximum length of a formatted ISO-8601 date. (Actually it's a bit bigger.) */
     static constexpr size_t kFormattedISO8601DateMaxSize = 40;

--- a/Fleece/Support/ParseDate.hh
+++ b/Fleece/Support/ParseDate.hh
@@ -57,6 +57,7 @@ namespace fleece {
         char validHMS;     /* True (1) if h,m,s are valid */
         char validJD;      /* True (1) if iJD is valid */
         char validTZ;      /* True (1) if tz is valid */
+        char separator;    /* The character used to separate the date and time (T or space) */
     };
 
     /** Parses a C string as an ISO-8601 date-time, returning a parsed DateTime struct */
@@ -67,7 +68,7 @@ namespace fleece {
 
     /** Converts an existing DateTime struct into a timestamp (milliseconds since 
          1/1/1970) */
-    int64_t ToMillis(DateTime& dt);
+    int64_t ToMillis(DateTime& dt, bool no_tz = false);
 
     /** Converts a timestamp (milliseconds since 1/1/1970) into a parsed DateTime struct
         in UTC time */
@@ -93,9 +94,19 @@ namespace fleece {
                     kFormattedISO8601DateMaxSize bytes must be available.
         @param timestamp  The timestamp (milliseconds since 1/1/1970).
         @param asUTC  True to format as UTC, false to use the local time-zone.
+        @param format The model to use for formatting (i.e. which portions to include).
+                      If null, then the full ISO-8601 format is used
         @return  The formatted string (points to `buf`). */
-    slice FormatISO8601Date(char buf[], int64_t timestamp, bool asUTC);
+    slice FormatISO8601Date(char buf[], int64_t timestamp, bool asUTC, const DateTime* format);
 
-    slice FormatISO8601Date(char buf[], int64_t timestamp, int tz);
+    /** Formats a timestamp (milliseconds since 1/1/1970) as an ISO-8601 date-time.
+        @param buf  The location to write the formatted C string. At least
+                    kFormattedISO8601DateMaxSize bytes must be available.
+        @param timestamp  The timestamp (milliseconds since 1/1/1970).
+        @param tz       The timezone offset from UTC in minutes
+        @param format The model to use for formatting (i.e. which portions to include).
+                      If null, then the full ISO-8601 format is used
+        @return  The formatted string (points to `buf`). */
+    slice FormatISO8601Date(char buf[], int64_t timestamp, int tz, const DateTime* format);
 }
 

--- a/Fleece/Support/ParseDate.hh
+++ b/Fleece/Support/ParseDate.hh
@@ -40,6 +40,30 @@ namespace fleece {
         kDateComponentInvalid
     } DateComponent;
 
+    /*
+     ** A structure for holding a single date and time.
+     */
+    typedef struct DateTime DateTime;
+    struct DateTime {
+        int64_t iJD;       /* The julian day number times 86400000 */
+        int Y, M, D;       /* Year, month, and day */
+        int h, m;          /* Hour and minutes */
+        int tz;            /* Timezone offset in minutes */
+        double s;          /* Seconds */
+        char validYMD;     /* True (1) if Y,M,D are valid */
+        char validHMS;     /* True (1) if h,m,s are valid */
+        char validJD;      /* True (1) if iJD is valid */
+        char validTZ;      /* True (1) if tz is valid */
+    };
+
+    DateTime ParseISO8601DateRaw(const char* dateStr);
+
+    DateTime ParseISO8601DateRaw(slice dateStr);
+
+    int64_t ToMillis(DateTime& dt);
+
+    DateTime FromMillis(int64_t millis);
+
     /** Parses a C string as an ISO-8601 date-time, returning a timestamp (milliseconds since
         1/1/1970), or kInvalidDate if the string is not valid. */
     int64_t ParseISO8601Date(const char* dateStr);
@@ -63,5 +87,6 @@ namespace fleece {
         @return  The formatted string (points to `buf`). */
     slice FormatISO8601Date(char buf[], int64_t timestamp, bool asUTC);
 
+    slice FormatISO8601Date(char buf[], int64_t timestamp, int tz);
 }
 


### PR DESCRIPTION
E.g. "year" or "day", in preparation for new N1QL functions

Note:  Makes use of third party header file "date.h" to extend C++ chrono support beyond hours and into days weeks and years (MIT License).  