### PR TITLE
Create a version of strerror for Windows

### DIFF
--- a/Fleece/Support/FleeceException.cc
+++ b/Fleece/Support/FleeceException.cc
@@ -21,8 +21,10 @@
 #include <errno.h>
 #include <memory>
 #include <stdarg.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <string.h>
 
 #ifdef _MSC_VER
 #include "asprintf.h"

--- a/Fleece/Support/PlatformCompat.hh
+++ b/Fleece/Support/PlatformCompat.hh
@@ -23,6 +23,9 @@
 #endif
 
 #ifdef _MSC_VER
+    #ifndef WIN32_LEAN_AND_MEAN
+    #define WIN32_LEAN_AND_MEAN
+    #endif
 
     #define NOINLINE                        __declspec(noinline)
 	#define LITECORE_UNUSED
@@ -48,6 +51,9 @@
 
     #define cbl_strdup _strdup
     #define cbl_getcwd _getcwd
+
+    #include <string>
+    std::string cbl_strerror(int err);
 
     #include <winapifamily.h>
 
@@ -75,6 +81,7 @@
 
     #define cbl_strdup strdup
     #define cbl_getcwd getcwd
+    #define cbl_strerror strerror
 
 #endif
 


### PR DESCRIPTION
The system version doesn't have enough error strings inside of it, so everything above 42 is "Unknown".  This implementation was taken from LiteCore after I discovered that `strerror` is used in various places throughout Fleece and LiteCore.