### PR TITLE
use locale independ way to convert string to double

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "vendor/jsonsl"]
 	path = vendor/jsonsl
 	url = https://github.com/snej/jsonsl.git
+[submodule "vendor/double-conversion"]
+	path = vendor/double-conversion
+	url = https://github.com/google/double-conversion

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,8 @@ matrix:
 before_install:
     - eval "${MATRIX_EVAL}"
 
-script: "cd build_cmake && ./build.sh"
+script:
+  - cd build_cmake && ./build.sh
+  - cd ..
+  - LC_NUMERIC="C" ./build_cmake/FleeceTests
+  - LC_NUMERIC="ru_RU.UTF-8" ./build_cmake/FleeceTests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,9 +27,12 @@ if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi")
 endif()
 
+add_subdirectory(vendor/double-conversion)
 set_source_files(RESULT FLEECE_SRC)
 add_library(Fleece        SHARED  ${FLEECE_SRC})
+target_link_libraries(Fleece double-conversion)
 add_library(FleeceStatic  STATIC  ${FLEECE_SRC})
+target_link_libraries(FleeceStatic double-conversion)
 
 # "FleeceBase" static lib for clients that just need support stuff like slice, varint, RefCounted...
 set_base_platform_files(RESULT FLEECE_BASE_PLATFORM_SRC)

--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -18,6 +18,7 @@
 
 #include "JSONConverter.hh"
 #include "jsonsl.h"
+#include "double-conversion/string-to-double.h"
 #include <map>
 
 namespace fleece { namespace impl {
@@ -114,8 +115,13 @@ namespace fleece { namespace impl {
                 unsigned f = state->special_flags;
                 if (f & JSONSL_SPECIALf_FLOAT) {
                     char *start = (char*)&_input[state->pos_begin];
-                    char *end;
-                    double n = ::strtod(start, &end);
+		    double_conversion::StringToDoubleConverter double_conv{
+                        double_conversion::StringToDoubleConverter::ALLOW_TRAILING_JUNK, 0., 0., "Infinity", "NaN"
+                    };
+		    int processed_characters_count = 0;
+		    double n = double_conv.StringToDouble(start,
+						      static_cast<int>(_input.size - state->pos_begin),
+						      &processed_characters_count);
                     _encoder.writeDouble(n);
                 } else if (f & JSONSL_SPECIALf_UNSIGNED) {
                     _encoder.writeUInt(state->nelem);

--- a/Fleece/Core/Value.cc
+++ b/Fleece/Core/Value.cc
@@ -31,6 +31,7 @@
 #include "ParseDate.hh"
 #include <math.h>
 #include "betterassert.hh"
+#include "double-conversion/double-to-string.h"
 
 
 namespace fleece { namespace impl {
@@ -198,11 +199,14 @@ namespace fleece { namespace impl {
                 break;
             }
             case kFloatTag: {
+                const auto &dbl_to_str = double_conversion::DoubleToStringConverter::EcmaScriptConverter();
+		double_conversion::StringBuilder str_builder{buf, static_cast<int>(sizeof(buf))};
                 if (_byte[0] & 0x8)
-                    sprintf(str, "%.16g", asDouble());
-                else
-                    sprintf(str, "%.6g", asFloat());
-                break;
+                    dbl_to_str.ToShortest(asDouble(), &str_builder);
+		else
+		    dbl_to_str.ToShortestSingle(asFloat(), &str_builder);
+
+                return alloc_slice(buf, str_builder.position());
             }
             default:
                 return alloc_slice(asString());

--- a/Fleece/Support/JSONEncoder.cc
+++ b/Fleece/Support/JSONEncoder.cc
@@ -22,6 +22,7 @@
 #include "ParseDate.hh"
 #include <algorithm>
 #include "betterassert.hh"
+#include "double-conversion/double-to-string.h"
 
 namespace fleece { namespace impl {
 
@@ -176,6 +177,24 @@ namespace fleece { namespace impl {
             default:
                 FleeceException::_throw(UnknownValue, "illegal typecode in Value; corrupt data?");
         }
+    }
+
+    void JSONEncoder::writeFloat(float f) {
+        comma();
+        char buf[32] = {0};
+	double_conversion::StringBuilder str_builder{buf, static_cast<int>(sizeof(buf))};
+	const auto &dbl_to_str = double_conversion::DoubleToStringConverter::EcmaScriptConverter();
+	dbl_to_str.ToShortestSingle(f, &str_builder);
+	_out.write(buf, str_builder.position());
+    }
+
+    void JSONEncoder::writeDouble(double d) {
+        comma();
+        char buf[32];
+	double_conversion::StringBuilder str_builder{buf, static_cast<int>(sizeof(buf))};
+	const auto &dbl_to_str = double_conversion::DoubleToStringConverter::EcmaScriptConverter();
+	dbl_to_str.ToShortest(d, &str_builder);
+	_out.write(buf, str_builder.position());
     }
 
 } }

--- a/Fleece/Support/JSONEncoder.hh
+++ b/Fleece/Support/JSONEncoder.hh
@@ -53,8 +53,8 @@ namespace fleece { namespace impl {
 
         void writeInt(int64_t i)                {writef("%lld", i);}
         void writeUInt(uint64_t i)              {writef("%llu", i);}
-        void writeFloat(float f)                {writef("%.6g", f);}
-        void writeDouble(double d)              {writef("%.16g", d);}
+        void writeFloat(float f);
+        void writeDouble(double d);
 
         void writeString(const std::string &s)  {writeString(slice(s));}
         void writeString(slice s);

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -25,6 +25,7 @@
 #include "jsonsl.h"
 #include "mn_wordlist.h"
 #include <iostream>
+#include <locale.h>
 #include <float.h>
 
 #ifndef _MSC_VER
@@ -38,7 +39,10 @@ class EncoderTests {
 public:
     EncoderTests()
     :enc()
-    { }
+    {
+        // to make sure that we don't depend on current locale
+        setlocale(LC_ALL, "");
+    }
 
     ~EncoderTests() {
         enc.reset();

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -564,11 +564,12 @@ public:
     TEST_CASE_METHOD(EncoderTests, "JSON", "[Encoder]") {
         slice json("{\"\":\"hello\\nt\\\\here\","
                             "\"\\\"ironic\\\"\":[null,false,true,-100,0,100,123.456,6.02e+23],"
-                            "\"foo\":123}");
+                            "\"foo\":123,"
+                            "\"foo2\":123.13274}");
         JSONConverter j(enc);
         REQUIRE(j.encodeJSON(json));
         endEncoding();
-        auto d = checkDict(3);
+        auto d = checkDict(4);
         auto output = d->toJSON();
         REQUIRE((slice)output == json);
     }

--- a/Tests/MutableTests.cc
+++ b/Tests/MutableTests.cc
@@ -116,7 +116,7 @@ namespace fleece {
             CHECK(!i);
         }
 
-        CHECK(ma->asArray()->toJSON() == "[null,false,true,0,-123,2017,123456789,-123456789,\"Hot dog\",3.14159,3.141592653589793]"_sl);
+        CHECK(ma->asArray()->toJSON() == "[null,false,true,0,-123,2017,123456789,-123456789,\"Hot dog\",3.1415927,3.141592653589793]"_sl);
 
         ma->remove(3, 5);
         CHECK(ma->count() == 6);

--- a/Tests/ObjCTests.mm
+++ b/Tests/ObjCTests.mm
@@ -57,7 +57,7 @@ TEST_CASE("Obj-C Ints", "[Encoder]") {
 TEST_CASE("Obj-C Floats", "[Encoder]") {
     checkIt(@0.5,  "0.5");
     checkIt(@-0.5, "-0.5");
-    checkIt(@((float)M_PI), "3.14159");
+    checkIt(@((float)M_PI), "3.1415927");
     checkIt(@((double)M_PI), "3.141592653589793");
 }
 


### PR DESCRIPTION
Related to couchbase/couchbase-lite-core#849 , should fix issue.
Plus this change should speedup json parsing, because of according to https://github.com/dropbox/json11/issues/38#issuecomment-214944965 when I replace in dropbox json library call strtod with google/double-conversation I see speedup in benchmark from 51ms to 40ms.

Though there is `isdigit` in vendor/jsonsl/jsonsl.c . `isdigit` locale dependent function also.
But this is related to other repository. I should note that I expect that replacing isidigit should also speedup things, because of most compilers can not inline isdigit, so check `if (ch >= '0' && ch <= '9')` is faster.