### PR TITLE
fix misside xlocale.h issue

### DIFF
--- a/Fleece/Support/NumConversion.cc
+++ b/Fleece/Support/NumConversion.cc
@@ -20,7 +20,7 @@
 #include "SwiftDtoa.h"
 #include <locale.h>
 #include <stdlib.h>
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) && !defined(__GLIBC__)
 #include <xlocale.h>
 #endif
 


### PR DESCRIPTION
locale.h is conforming POSIX.1‐2008, while xlocale.h is not standard heder and was removed from glibc since version 2.26:

https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html

* The nonstandard header <xlocale.h> has been removed.  Most programs should
  use <locale.h> instead.  If you have a specific need for the definition of
  locale_t with no other declarations, please contact
  libc-alpha@sourceware.org and explain.


So build failed on all recent Linux ditros.