### PR TITLE
CBL-540: fix: memory leak with platform string

### DIFF
--- a/Fleece/Core/SharedKeys.cc
+++ b/Fleece/Core/SharedKeys.cc
@@ -21,6 +21,14 @@
 #include "FleeceException.hh"
 
 
+#ifdef __APPLE__
+#include <CoreFoundation/CFString.h>
+typedef CFStringRef PlatformString;
+#else
+typedef void* PlatformString;
+#endif
+
+
 #define LOCK(MUTEX)     lock_guard<mutex> _lock(MUTEX)
 
 
@@ -155,7 +163,11 @@ namespace fleece { namespace impl {
         LOCK(_mutex);
         if ((unsigned)key >= _platformStringsByKey.size())
             _platformStringsByKey.resize(key + 1);
+#ifdef __APPLE__
+        _platformStringsByKey[key] = CFRetain(platformKey);
+#else
         _platformStringsByKey[key] = platformKey;
+#endif
     }
 
 

--- a/Fleece/Core/SharedKeys.cc
+++ b/Fleece/Core/SharedKeys.cc
@@ -21,14 +21,6 @@
 #include "FleeceException.hh"
 
 
-#ifdef __APPLE__
-#include <CoreFoundation/CFString.h>
-typedef CFStringRef PlatformString;
-#else
-typedef void* PlatformString;
-#endif
-
-
 #define LOCK(MUTEX)     lock_guard<mutex> _lock(MUTEX)
 
 
@@ -173,7 +165,7 @@ namespace fleece { namespace impl {
         if ((unsigned)key >= _platformStringsByKey.size())
             _platformStringsByKey.resize(key + 1);
 #ifdef __APPLE__
-        _platformStringsByKey[key] = CFRetain(platformKey);
+        _platformStringsByKey[key] = CFStringCreateCopy(kCFAllocatorDefault, platformKey);
 #else
         _platformStringsByKey[key] = platformKey;
 #endif

--- a/Fleece/Core/SharedKeys.cc
+++ b/Fleece/Core/SharedKeys.cc
@@ -36,6 +36,15 @@ namespace fleece { namespace impl {
     using namespace std;
 
 
+    SharedKeys::~SharedKeys() {
+    #ifdef __APPLE__
+        for (auto &str : _platformStringsByKey) {
+            if (str)
+                CFRelease(str);
+        }
+    #endif
+    }
+
     key_t::key_t(const Value *v) noexcept {
         if (v->isInteger())
             _int = (int16_t)v->asInt();

--- a/Fleece/Core/SharedKeys.hh
+++ b/Fleece/Core/SharedKeys.hh
@@ -23,6 +23,10 @@
 #include <mutex>
 #include <vector>
 
+#ifdef __APPLE__
+#include <CoreFoundation/CFString.h>
+#endif
+
 
 namespace fleece { namespace impl {
     class Value;
@@ -108,7 +112,11 @@ namespace fleece { namespace impl {
         static const size_t kMaxCount = 2048;               // Max number of keys to store
         static const size_t kDefaultMaxKeyLength = 16;      // Max length of string to store
 
+#ifdef __APPLE__
+        typedef CFStringRef PlatformString;
+#else
         typedef const void* PlatformString;
+#endif
 
         /** Allows an uninterpreted value (like a pointer to a platform String object) to be
             associated with an encoded key. */

--- a/Fleece/Core/SharedKeys.hh
+++ b/Fleece/Core/SharedKeys.hh
@@ -116,7 +116,7 @@ namespace fleece { namespace impl {
         PlatformString platformStringForKey(int key) const;
 
     protected:
-        virtual ~SharedKeys() =default;
+        virtual ~SharedKeys();
         virtual bool loadFrom(slice stateData);
 
         /** Determines whether a new string should be added. Default implementation returns true

--- a/ObjC/Value+ObjC.mm
+++ b/ObjC/Value+ObjC.mm
@@ -160,7 +160,7 @@ namespace fleece { namespace impl {
                     if (strSlice) {
                         keyStr = convertString(strSlice);
                         sk->setPlatformStringForKey(encodedKey,
-                                                    CFRetain((__bridge CFStringRef)keyStr));
+                                                    (__bridge CFStringRef)keyStr);
                         //TODO: Strings need to be CFRelease'd when the SharedKeys is destructed.
 #if LOG_CACHED_STRINGS
                         fprintf(stderr, "SHAREDKEY[%p] %d --> %s\n", sk, encodedKey, keyStr.UTF8String);


### PR DESCRIPTION
* include destructor specific to platform, so that CFString can be released