### PR TITLE
fix: doc leak

### DIFF
--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -345,11 +345,8 @@ namespace fleece {
             FLTrust trust =kFLUntrusted,
             SharedKeys sk =nullptr,
             slice externDestination =nullslice) noexcept
-        {
-            FLSliceResult res = FLSliceResult(fleeceData);
-            _doc = FLDoc_FromResultData(res, trust, sk, externDestination);
-            FLSliceResult_Free(res);
-        }
+        :_doc(FLDoc_FromResultData({fleeceData.buf, fleeceData.size}, trust, sk, externDestination))
+        { }
 
         static inline Doc fromJSON(slice_NONNULL json, FLError *outError = nullptr);
 

--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -345,8 +345,11 @@ namespace fleece {
             FLTrust trust =kFLUntrusted,
             SharedKeys sk =nullptr,
             slice externDestination =nullslice) noexcept
-        :_doc(FLDoc_FromResultData(FLSliceResult(fleeceData), trust, sk, externDestination))
-        { }
+        {
+            FLSliceResult res = FLSliceResult(fleeceData);
+            _doc = FLDoc_FromResultData(res, trust, sk, externDestination);
+            FLSliceResult_Free(res);
+        }
 
         static inline Doc fromJSON(slice_NONNULL json, FLError *outError = nullptr);
 


### PR DESCRIPTION
Before
1. FLSliceResult(fleeceData) creates a copy and retains +1
2. FLDoc_FromResultData holds the alloc_slice, inside FLDoc instance +2
3. (later)FLDoc_Release called and stored alloc_slice, inside FLDoc releases +1

After 
1. FLSliceResult(fleeceData) creates a copy and retains +1
2. FLDoc_FromResultData holds the alloc_slice, inside FLDoc instance +2
3. Release the copy of result from step 1. +1
3. (later)FLDoc_Release called and stored alloc_slice, inside FLDoc releases +1