### PR TITLE
Safety fixes for Encoder::writeKey(Value*)

### DIFF
--- a/Fleece/Core/Encoder.hh
+++ b/Fleece/Core/Encoder.hh
@@ -144,12 +144,8 @@ namespace fleece { namespace impl {
         /** Writes a key to the current dictionary. This must be called before adding a value. */
         void writeKey(slice);
 
-        /** Writes a numeric key (encoded with SharedKeys) to the current dictionary. */
-        void writeKey(int);
-
-        /** Writes a string Value as a key to the current dictionary. */
-        void writeKey(const Value* NONNULL);
-        void writeKey(const Value* NONNULL, const SharedKeys*);
+        /** Writes a string or int Value as a key to the current dictionary. */
+        void writeKey(const Value* NONNULL, const SharedKeys* =nullptr);
 
         void writeKey(key_t);
 
@@ -226,6 +222,7 @@ namespace fleece { namespace impl {
         void endCollection(internal::tags tag);
         void push(internal::tags tag, size_t reserve);
         inline void pop();
+        void writeKey(int);
         void writeValue(const Value* NONNULL, const WriteValueFunc*);
         void writeValue(const Value* NONNULL, const SharedKeys* &, const WriteValueFunc*);
         const Value* minUsed(const Value *value);

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -163,11 +163,11 @@ public:
         for (unsigned i = 0; i < length; ++i) {
             auto v = a->get(i);
             if (!v || v->type() != kNumber || v->asUnsigned() != (uint64_t)i) {
-            REQUIRE(v);
-            REQUIRE(v->type() == kNumber);
-            REQUIRE(v->asUnsigned() == (uint64_t)i);
+                REQUIRE(v);
+                REQUIRE(v->type() == kNumber);
+                REQUIRE(v->asUnsigned() == (uint64_t)i);
+            }
         }
-    }
     }
 
     void checkJSONStr(std::string json,
@@ -208,6 +208,10 @@ public:
         REQUIRE(name);
         nameStr = (std::string)name->asString();
         REQUIRE(nameStr == expectedName);
+    }
+
+    void writeKey(int key) {
+        enc.writeKey(key);
     }
 
 };
@@ -456,11 +460,11 @@ public:
         gDisableNecessarySharedKeysCheck = true;
         {
             enc.beginDictionary();
-            enc.writeKey(0);
+            writeKey(0);
             enc.writeInt(23);
-            enc.writeKey(1);
+            writeKey(1);
             enc.writeInt(42);
-            enc.writeKey(2047);
+            writeKey(2047);
             enc.writeInt(-1);
             enc.endDictionary();
             checkOutput("7003 0000 0017 0001 002A 07FF 0FFF 8007");


### PR DESCRIPTION
Ensure it won't write an integer key belonging to a different
SharedKeys, which would result in the wrong key string.
(This is a speculative fix, since I haven't seen this occur, but I
have suspicions this might be behind CBSE-7789.)