### PR TITLE
Added Backtrace::installTerminateHandler()

### DIFF
--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -13,8 +13,10 @@ namespace fleece {
     /** Captures a backtrace of the current thread, and converts it to human-readable form. */
     class Backtrace {
     public:
-        Backtrace(unsigned skipFrames =0);
+        explicit Backtrace(unsigned skipFrames =0);
+#ifdef __clang__
         ~Backtrace();
+#endif
 
         bool writeTo(std::ostream&);
         std::string toString();
@@ -26,14 +28,24 @@ namespace fleece {
 
         frameInfo getFrame(unsigned);
 
+        /// Installs a C++ terminate_handler that will log a backtrace and info about any uncaught
+        /// exception. By default it then calls the preexisting terminate_handler, which usually
+        /// calls abort().
+        ///
+        /// Since the OS will not usually generate a crash report upon a SIGABORT, you can set
+        /// `andRaise` to a different signal ID such as SIGILL to force a crash.
+        ///
+        /// Only the first call to this function has any effect; subsequent calls are ignored.
+        static void installTerminateHandler(int andRaise =0);
+
     private:
         static constexpr size_t kMaxAddrs = 50;
         unsigned const _skip;
         void* _addrs[kMaxAddrs];
         unsigned _nAddrs;
 
-#ifndef _MSC_VER
         const char* unmangle(const char*);
+#ifdef __clang__
         char* _unmangled {nullptr};
         size_t _unmangledLen {0};
 #endif


### PR DESCRIPTION
Utility to log a backtrace upon an uncaught exception.