### PR TITLE
fix: CBL-649: nsexception handled

### DIFF
--- a/ObjC/Encoder+ObjC.mm
+++ b/ObjC/Encoder+ObjC.mm
@@ -52,6 +52,8 @@ bool FLEncoder_WriteNSObject(FLEncoder encoder, id obj) FLAPI {
         return true;
     } catch (const std::exception &x) {
         encoder->recordException(x);
+    } catch (NSException* e) {
+        encoder->recordException(FleeceException(EncodeError, 0, e.reason.UTF8String));
     }
     return false;
 }


### PR DESCRIPTION
* when nsexception is thrown from CBL, it is not gettig caught in std::exception
* this fix will handle the nsexception and record the errorCode and message