### PR TITLE
CBL-978 Disable implicit fleece float -> int conversion

### DIFF
--- a/Fleece/Core/Encoder.cc
+++ b/Fleece/Core/Encoder.cc
@@ -234,9 +234,12 @@ namespace fleece { namespace impl {
 
     void Encoder::writeDouble(double n) {
         throwIf(std::isnan(n), InvalidData, "Can't write NaN");
+#if 0 // Perhaps an option in the future?
         if (isIntRepresentable(n)) {
             return writeInt((int64_t)n);
-        } else if (isFloatRepresentable(n)) {
+        } else
+#endif
+        if (isFloatRepresentable(n)) {
             return _writeFloat((float)n);
         } else {
             endian::littleEndianDouble swapped = n;
@@ -248,9 +251,11 @@ namespace fleece { namespace impl {
 
     void Encoder::writeFloat(float n) {
         throwIf(std::isnan(n), InvalidData, "Can't write NaN");
+#if 0 // Perhaps an option in the future?
         if (isIntRepresentable(n))
             writeInt((int32_t)n);
         else
+#endif
             _writeFloat(n);
     }
 
@@ -261,6 +266,7 @@ namespace fleece { namespace impl {
         memcpy(&buf[2], &swapped, sizeof(swapped));
     }
 
+#if 0
     bool Encoder::isIntRepresentable(float n) noexcept {
         return (n <= INT32_MAX && n >= INT32_MIN && n == floorf(n));
     }
@@ -268,6 +274,7 @@ namespace fleece { namespace impl {
     bool Encoder::isIntRepresentable(double n) noexcept {
         return (n <= INT64_MAX && n >= INT64_MIN && n == floor(n));
     }
+#endif
 
     bool Encoder::isFloatRepresentable(double n) noexcept {
         return (fabs(n) <= FLT_MAX && n == (float)n);

--- a/Fleece/Core/Encoder.hh
+++ b/Fleece/Core/Encoder.hh
@@ -178,8 +178,10 @@ namespace fleece { namespace impl {
         slice baseUsed() const                  {return _baseMinUsed != 0 ? slice(_baseMinUsed, _base.end()) : slice();}
         const StringTable& strings() const      {return _strings;}
 
+#if 0
         static bool isIntRepresentable(float n) noexcept;
         static bool isIntRepresentable(double n) noexcept;
+#endif
         static bool isFloatRepresentable(double n) noexcept;
 
     private:

--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -179,9 +179,12 @@ namespace fleece { namespace impl {
 
 
     void ValueSlot::set(float f) {
+#if 0 // Perhaps an option in the future?
         if (Encoder::isIntRepresentable(f)) {
             set((int32_t)f);
-        } else {
+        } else
+#endif
+        {
             struct {
                 uint8_t filler = 0;
                 endian::littleEndianFloat le;
@@ -193,9 +196,12 @@ namespace fleece { namespace impl {
     }
 
     void ValueSlot::set(double d) {
+#if 0 // Perhaps an option in the future?
         if (Encoder::isIntRepresentable(d)) {
             set((int64_t)d);
-        } else {
+        } else
+#endif
+        {
             struct {
                 uint8_t filler = 0;
                 endian::littleEndianDouble le;


### PR DESCRIPTION
Otherwise it may lead to situations where math results are incorrect because both sides turned into ints (e.g. 5.0 / 15.0 != 5 / 15)