### PR TITLE
Avoid undefined behavior calling memcmp & memcpy

### DIFF
--- a/API/fleece/FLSlice.h
+++ b/API/fleece/FLSlice.h
@@ -80,6 +80,22 @@ typedef FLSliceResult FLStringResult;
 #endif
 
 
+/** Exactly like memcmp, but safely handles the case where a or b is NULL and size is 0 (by returning 0),
+    instead of producing "undefined behavior" as per the C spec. */
+static inline FLPURE int FLMemCmp(const void *a, const void *b, size_t size) FLAPI {
+    if (_usuallyFalse(size == 0))
+        return 0;
+    return memcmp(a, b, size);
+}
+
+/** Exactly like memcmp, but safely handles the case where dst or src is NULL and size is 0 (as a no-op),
+    instead of producing "undefined behavior" as per the C spec. */
+static inline void FLMemCpy(void *dst, const void *src, size_t size) FLAPI {
+    if (_usuallyTrue(size > 0))
+        memcpy(dst, src, size);
+}
+
+
 /** Returns a slice pointing to the contents of a C string.
     It's OK to pass NULL; this returns an empty slice.
     (Performance is O(n) with the length of the string, since it has to call `strlen`.) */

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -97,6 +97,7 @@ namespace fleece {
 #ifdef SLICE_SUPPORTS_STRING_VIEW
         constexpr pure_slice(string_view str) noexcept            :pure_slice(str.data(), str.length()) {}
 #endif
+        operator FLSlice () const noexcept                          {return {buf, size};}
 
         explicit operator bool() const noexcept FLPURE              {return buf != nullptr;}
 
@@ -118,11 +119,10 @@ namespace fleece {
         const uint8_t* findAnyByteOf(pure_slice targetBytes) const noexcept FLPURE;
         const uint8_t* findByteNotIn(pure_slice targetBytes) const noexcept FLPURE;
 
-        int compare(pure_slice) const noexcept FLPURE;
+        int compare(pure_slice s) const noexcept FLPURE          {return FLSlice_Compare(*this, s);}
         int caseEquivalentCompare(pure_slice) const noexcept FLPURE;
         bool caseEquivalent(pure_slice) const noexcept FLPURE;
-        bool operator==(const pure_slice &s) const noexcept FLPURE       {return size==s.size &&
-                                                                 memcmp(buf, s.buf, size) == 0;}
+        bool operator==(const pure_slice &s) const noexcept FLPURE {return FLSlice_Equal(*this, s);}
         bool operator!=(const pure_slice &s) const noexcept FLPURE       {return !(*this == s);}
         bool operator<(pure_slice s) const noexcept FLPURE               {return compare(s) < 0;}
         bool operator>(pure_slice s) const noexcept FLPURE               {return compare(s) > 0;}
@@ -271,7 +271,6 @@ namespace fleece {
         void free() noexcept;
 
         constexpr slice(const FLSlice &s) noexcept           :slice(s.buf, s.size) { }
-        operator FLSlice () const noexcept                   {return {buf, size};}
         inline explicit operator FLSliceResult () const noexcept;
 
 #ifdef __APPLE__
@@ -371,7 +370,6 @@ namespace fleece {
         static void retain(slice s) noexcept                {((alloc_slice*)&s)->retain();}
         static void release(slice s) noexcept               {((alloc_slice*)&s)->release();}
 
-        operator FLSlice () const noexcept                  {return {buf, size};}
         operator FLHeapSlice () const noexcept              {return {buf, size};}
         explicit operator FLSliceResult () noexcept         {retain(); return {(void*)buf, size};}
 

--- a/Experimental/KeyTree.cc
+++ b/Experimental/KeyTree.cc
@@ -119,7 +119,7 @@ namespace fleece {
         }
 
         inline void write(slice s) {
-            memcpy(_out, s.buf, s.size);
+            FLMemCpy(_out, s.buf, s.size);
             _out += s.size;
         }
 

--- a/Fleece/API_Impl/FLSlice.cc
+++ b/Fleece/API_Impl/FLSlice.cc
@@ -22,20 +22,22 @@
 #include "betterassert.hh"
 
 
+__hot
 bool FLSlice_Equal(FLSlice a, FLSlice b) FLAPI {
-    return a.size==b.size && memcmp(a.buf, b.buf, a.size) == 0;
+    return a.size == b.size && FLMemCmp(a.buf, b.buf, a.size) == 0;
 }
 
 
+__hot
 int FLSlice_Compare(FLSlice a, FLSlice b) FLAPI {
-    // Optimized for speed
+    // Optimized for speed, not simplicity!
     if (a.size == b.size)
-        return memcmp(a.buf, b.buf, a.size);
+        return FLMemCmp(a.buf, b.buf, a.size);
     else if (a.size < b.size) {
-        int result = memcmp(a.buf, b.buf, a.size);
+        int result = FLMemCmp(a.buf, b.buf, a.size);
         return result ? result : -1;
     } else {
-        int result = memcmp(a.buf, b.buf, b.size);
+        int result = FLMemCmp(a.buf, b.buf, b.size);
         return result ? result : 1;
     }
 }
@@ -132,7 +134,7 @@ FLSliceResult FLSlice_Copy(FLSlice s) FLAPI {
     auto sb = new (s.size) sharedBuffer;
     if (!sb)
         return {};
-    memcpy(&sb->_buf, s.buf, s.size);
+    FLMemCpy(&sb->_buf, s.buf, s.size);
     return {&sb->_buf, s.size};
 }
 

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -54,7 +54,7 @@ FLValue FLValue_FromData(FLSlice data, FLTrust trust) FLAPI {
 const char* FLDump(FLValue v) FLAPI {
     FLStringResult json = FLValue_ToJSON(v);
     auto cstr = (char*)malloc(json.size + 1);
-    memcpy(cstr, json.buf, json.size);
+    FLMemCpy(cstr, json.buf, json.size);
     cstr[json.size] = 0;
     return cstr;
 }

--- a/Fleece/Mutable/HeapValue.cc
+++ b/Fleece/Mutable/HeapValue.cc
@@ -48,7 +48,7 @@ namespace fleece { namespace impl { namespace internal {
 
     HeapValue* HeapValue::create(tags tag, int tiny, slice extraData) {
         auto hv = new (extraData.size) HeapValue(tag, tiny);
-        memcpy(&hv->_header + 1, extraData.buf, extraData.size);
+        FLMemCpy(&hv->_header + 1, extraData.buf, extraData.size);
         return hv;
     }
 

--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -238,7 +238,7 @@ namespace fleece { namespace impl {
         releaseValue();
         if (1 + bytes.size <= kInlineCapacity) {
             _inlineData[0] = uint8_t((valueTag << 4) | tiny);
-            memcpy(&_inlineData[1], bytes.buf, bytes.size);
+            FLMemCpy(&_inlineData[1], bytes.buf, bytes.size);
             _isInline = true;
         } else {
             _asValue = retain(HeapValue::create(valueTag, tiny, bytes)->asValue());
@@ -251,7 +251,7 @@ namespace fleece { namespace impl {
         if (s.size + 1 <= kInlineCapacity) {
             // Short strings can go inline:
             setInline(valueTag, (int)s.size);
-            memcpy(&_inlineData[1], s.buf, s.size);
+            FLMemCpy(&_inlineData[1], s.buf, s.size);
         } else {
             releaseValue();
             _asValue = retain(HeapValue::createStr(valueTag, s)->asValue());

--- a/Fleece/Support/ParseDate.cc
+++ b/Fleece/Support/ParseDate.cc
@@ -413,7 +413,7 @@ namespace fleece {
         auto cstr = (char*)malloc(date.size + 1);
         if (!cstr)
             return kInvalidDate;
-        memcpy(cstr, date.buf, date.size);
+        FLMemCpy(cstr, date.buf, date.size);
         cstr[date.size] = 0;
         int64_t timestamp = ParseISO8601Date(cstr);
         free(cstr);


### PR DESCRIPTION
The C standard says that memcmp, memcpy and memmove produce the
dreaded Undefined Behavior if passed a NULL pointer, even if the size
parameter is zero. Nothing bad can actually occur at runtime in this
situation ... however, the optimizer can use the guarantee of non-null
pointers to make incorrect decisions and produce bad code around
such a call.

So I've added safe functions FLMemCmp and FLMemCpy that do allow NULL
pointers and skip the memcmp/memcpy call when the size is zero.
And I've changed existing memcmp/memcpy calls that might be passed
NULL into the corresponding safe calls.

Fixes #73