### PR TITLE
Remove support lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
           packages:
             - g++-7
       env:
-        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
     - name: Linux Clang 5
       os: linux
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,14 @@ language: cpp
 
 matrix:
   include:
-    - name: Linux GCC 6
+    - name: Linux GCC 7
       os: linux
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-6
+            - g++-7
       env:
         - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
     - name: Linux Clang 5
@@ -20,17 +20,9 @@ matrix:
             - clang-5.0
       env:
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
-    - name: Linux Clang 3.9
-      os: linux
-      addons:
-        apt:
-          packages:
-            - clang-3.9
-      env:
-        - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
-    - name: Mac Clang (Xcode 9)
+    - name: Mac Clang (Xcode 10)
       os: osx
-      osx_image: xcode9
+      osx_image: xcode10
       
 before_install:
     - eval "${MATRIX_EVAL}"

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -39,13 +39,9 @@ struct __CFData;
 #endif
 
 // Figure out whether and how string_view is available
-#if __cplusplus >= 201700L || _MSVC_LANG >= 201700L
+#ifdef __has_include
     #if __has_include(<string_view>)
-        #include <string_view>
-        #define STRING_VIEW std::string_view
-    #else
-        #include <experimental/string_view>
-        #define STRING_VIEW std::experimental::string_view
+        #define SLICE_SUPPORTS_STRING_VIEW
     #endif
 #endif
 
@@ -60,10 +56,8 @@ namespace fleece {
     struct alloc_slice;
     struct nullslice_t;
 
-#ifdef STRING_VIEW
-    using string_view = STRING_VIEW; // create typedef with correct namespace
-    #undef STRING_VIEW
-    #define SLICE_SUPPORTS_STRING_VIEW
+#ifdef SLICE_SUPPORTS_STRING_VIEW
+    using string_view = std::string_view; // create typedef with correct namespace
 #endif
 
 #ifdef __APPLE__

--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -37,7 +37,7 @@
     #include <unwind.h>     // _Unwind_Backtrace(), etc.
 #endif
 
-#ifdef __clang__
+#ifdef _LIBCPP_VERSION
     #include <cxxabi.h>     // abi::__cxa_demangle()
 #endif
 
@@ -85,7 +85,7 @@ namespace fleece {
     { }
 
 
-#ifdef __clang__
+#ifdef _LIBCPP_VERSION
     Backtrace::~Backtrace() {
         free(_unmangled);
     }
@@ -110,7 +110,7 @@ namespace fleece {
 
 
     const char* Backtrace::unmangle(const char *function) {
-#ifdef __clang__
+#ifdef _LIBCPP_VERSION
         int status;
         _unmangled = abi::__cxa_demangle(function, _unmangled, &_unmangledLen, &status);
         if (_unmangled && status == 0)

--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -15,7 +15,7 @@ namespace fleece {
     class Backtrace {
     public:
         explicit Backtrace(unsigned skipFrames =0);
-#ifdef __clang__
+#ifdef _LIBCPP_VERSION
         ~Backtrace();
 #endif
 

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -74,16 +74,12 @@ function(setup_build)
     )
 
     target_link_libraries(
-        Fleece
+        FleeceStatic INTERFACE
         "-framework CoreFoundation"
         "-framework Foundation"
     )
 endfunction()
 
 function(setup_test_build)
-    target_link_libraries(
-        FleeceTests
-        "-framework CoreFoundation"
-        "-framework Foundation"
-    )
+    
 endfunction()

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -27,7 +27,10 @@ function(set_test_source_files)
 endfunction()
 
 function(setup_build)
-    # No-op
+    target_link_libraries(
+        FleeceStatic INTERFACE
+	dl
+    )
 endfunction()
 
 function(setup_test_build)


### PR DESCRIPTION
This is for an upstream LiteCore PR of the same name which both removes the support library and makes it easier to link things correctly by having each target export what they need to link with / include rather than having the consuming targets guess.