### PR TITLE
Fix ARM64 MVS build

### DIFF
--- a/Fleece/Support/Bitmap.cc
+++ b/Fleece/Support/Bitmap.cc
@@ -41,7 +41,7 @@ namespace fleece {
     }
 
 
-#ifndef _M_ARM
+#if !defined(_M_ARM) && !defined(_M_ARM64)
     static bool _can_popcnt = false;
     static void detect_popcnt()
     {
@@ -70,7 +70,7 @@ namespace fleece {
 #endif
 
     int _popcount(unsigned int v) noexcept {
-#ifndef _M_ARM
+#if !defined(_M_ARM) && !defined(_M_ARM64)
         return can_popcnt() ? __popcnt(v) : popcount_c(v);
 #else
         return popcount_c(v);
@@ -78,7 +78,7 @@ namespace fleece {
     }
 
     int _popcountl(unsigned long v) noexcept {
-#ifndef _M_ARM
+#if !defined(_M_ARM) && !defined(_M_ARM64)
         return can_popcnt() ? __popcnt(v) : popcount_c(v);
 #else
         return popcount_c(v);
@@ -86,13 +86,13 @@ namespace fleece {
     }
 
     int _popcountll(unsigned long long v) noexcept {
-#ifdef _WIN64
+#if defined(_WIN64) && !defined(_M_ARM64)
         return can_popcnt() ? (int)__popcnt64(v) : popcount_c(v);
 #else
         return popcount_c(v);
 #endif
     }
-    
+
 }
 
 #endif // _MSC_VER

--- a/Fleece/Support/endianness.h
+++ b/Fleece/Support/endianness.h
@@ -66,7 +66,7 @@
      defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || \
      defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) || \
      defined(_M_IX86) || defined(_M_X64) || defined(_M_IA64) || /* msvc for intel processors */ \
-     defined(_M_ARM) /* msvc code on arm executes in little endian mode */
+     defined(_M_ARM) ||  defined(_M_ARM64) /* msvc code on arm executes in little endian mode */
 #    define __LITTLE_ENDIAN__
 #  endif
 #endif
@@ -114,7 +114,6 @@
 
 /* Defines network - host byte swaps as needed depending upon platform endianness */
 // note that network order is big endian)
-
 #if defined(__LITTLE_ENDIAN__)
 #  define ntoh16(x)     bswap16((x))
 #  define hton16(x)     bswap16((x))
@@ -130,7 +129,7 @@
 #  define ntoh64(x)     (x)
 #  define hton64(x)     (x)
 #  else
-#    warning "UNKNOWN Platform / endianness; network / host byte swaps not defined."
+#   pragma message ("warning: UNKNOWN Platform / endianness; network / host byte swaps not defined.")
 #endif
 
 


### PR DESCRIPTION
The build on MVS 16 2019 for Debug|ARM64 was not working.