### PR TITLE
Retained: optimizations

### DIFF
--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -207,7 +207,7 @@ bool FLArrayIterator_Next(FLArrayIterator* i) FLAPI {
 
 static FLMutableArray _newMutableArray(FLArray a, FLCopyFlags flags) noexcept {
     try {
-        return (MutableArray*)retain(MutableArray::newArray(a, CopyFlags(flags)).get());
+        return (MutableArray*)retain(MutableArray::newArray(a, CopyFlags(flags)));
     } catchError(nullptr)
     return nullptr;
 }
@@ -327,7 +327,7 @@ FLValue FLDict_GetWithKey(FLDict d, FLDictKey *k) FLAPI {
 
 static FLMutableDict _newMutableDict(FLDict d, FLCopyFlags flags) noexcept {
     try {
-        return (MutableDict*)retain(MutableDict::newDict(d, CopyFlags(flags)).get());
+        return (MutableDict*)retain(MutableDict::newDict(d, CopyFlags(flags)));
     } catchError(nullptr)
     return nullptr;
 }
@@ -584,7 +584,7 @@ FLDoc FLEncoder_FinishDoc(FLEncoder e, FLError *outError) FLAPI {
     if (e->fleeceEncoder) {
         if (!e->hasError()) {
             try {
-                return retain(e->fleeceEncoder->finishDoc().get());       // finish() can throw
+                return retain(e->fleeceEncoder->finishDoc());       // finish() can throw
             } catch (const std::exception &x) {
                 e->recordException(x);
             }
@@ -625,7 +625,7 @@ FLDoc FLDoc_FromResultData(FLSliceResult data, FLTrust trust, FLSharedKeys sk, F
 
 FLDoc FLDoc_FromJSON(FLSlice json, FLError *outError) FLAPI {
     try {
-        return retain(Doc::fromJSON(json).get());
+        return retain(Doc::fromJSON(json));
     } catchError(outError);
     return nullptr;
 }

--- a/Fleece/Mutable/HeapValue.cc
+++ b/Fleece/Mutable/HeapValue.cc
@@ -150,7 +150,7 @@ namespace fleece { namespace impl { namespace internal {
                 FleeceException::_throw(InvalidData,
                                         "Can't retain immutable Value %p that's not part of a Doc",
                                         v);
-            fleece::retain(doc.get());
+            fleece::retain(move(doc));
         }
         return v;
     }


### PR DESCRIPTION
* Optimized Retained's rvalue assignment: I realized it could just do a swap of the two pointers.
* Added a method retain(Retained&&) for use by bridging functions that return a retained raw pointer. Changing `return retain(r.get())` to `return retain(std::move(r))` saves a retain and a release call.
* Plus some whitespace cleanup and comment tweaks.