### PR TITLE
expose isFleece API

### DIFF
--- a/API/fleece/Fleece.h
+++ b/API/fleece/Fleece.h
@@ -1135,6 +1135,9 @@ while (NULL != (value = FLDictIterator_GetValue(&iter))) {
     /** Returns the error message of an encoder, or NULL if there's no error. */
     const char* FLEncoder_GetErrorMessage(FLEncoder FLNONNULL) FLAPI;
 
+    /** Returns whether the encoder is fleece or not*/
+    bool FLEncoder_isFleece(FLEncoder FLNONNULL) FLAPI;
+
     /** @} */
     /** @} */
 

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -708,6 +708,11 @@ FLSliceResult FLEncoder_Finish(FLEncoder e, FLError *outError) FLAPI {
     e->reset();
     return {nullptr, 0};
 }
+    
+    
+bool FLEncoder_isFleece(FLEncoder e) FLAPI {
+    return e->isFleece();
+}
 
 
 #pragma mark - DOCUMENTS


### PR DESCRIPTION
* this will enable us to include content or not, when encoding blob. 
* Blob requires to encode content, when encode as Query params(Fleece encoder), where as when encode as JSON string, it didn't require the content(JSON Encoder).
* usage can be found in the linked lite-ios PR (couchbase/couchbase-lite-ios#2812)