### PR TITLE
CBL-1763: FLError not set on truncated JSON

### DIFF
--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -87,6 +87,7 @@ namespace fleece { namespace impl {
         if (_jsn->level > 0 && !_jsonError) {
             // Input is valid JSON so far, but truncated:
             _jsonError = kErrTruncatedJSON;
+            _errorCode = JSONError;
             _errorPos = json.size;
         }
         jsonsl_reset(_jsn);

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -26,6 +26,7 @@
 #include "mn_wordlist.h"
 #include "NumConversion.hh"
 #include <iostream>
+#include "fleece/Fleece.hh"
 #include <float.h>
 
 #ifndef _MSC_VER
@@ -1120,6 +1121,15 @@ public:
             INFO("Checking \"" << str << "\"");
             CHECK(!ParseInteger(str, result));
         }
+    }
+
+    TEST_CASE("Truncated JSON") {
+        // https://issues.couchbase.com/browse/CBL-1763
+        fleece::Encoder enc;
+        REQUIRE(!FLEncoder_ConvertJSON(enc, "{"_sl));
+        CHECK(enc.error() == kFLJSONError);
+        std::string msg = enc.errorMessage();
+        CHECK(msg == "Truncated JSON");
     }
 
 } }


### PR DESCRIPTION
Since it doesn't go through the standard "gotError" path.