### PR TITLE
Fix a reference-leak bug, #CBL-1707

### DIFF
--- a/Fleece/Integration/MDict.hh
+++ b/Fleece/Integration/MDict.hh
@@ -64,6 +64,7 @@ namespace fleece {
             MCollection::initAsCopyOf(d, isMutable);
             _dict = d._dict;
             _map = d._map;
+            _newKeys = d._newKeys;
             _count = d._count;
         }
 
@@ -137,8 +138,9 @@ namespace fleece {
                 return true;
             MCollection::mutate();
             _map.clear();
+            _newKeys.clear();
             for (Dict::iterator i(_dict); i; ++i)
-                _map.emplace(i.keyString(), MValue::empty);
+                _setInMap(i.keyString(), MValue::empty);
             _count = 0;
             return true;
         }

--- a/Fleece/Integration/MDictIterator.hh
+++ b/Fleece/Integration/MDictIterator.hh
@@ -55,6 +55,7 @@ namespace fleece {
                     return *_mvalue;
                 // Fleece Dict iterator doesn't have an MValue, so add the key/value to the _map:
                 auto i = const_cast<MDict&>(_dict)._setInMap(_key, MValue(_dictIter.value()));
+                _key = i->first;
                 _mvalue = &i->second;
                 return *_mvalue;
             }


### PR DESCRIPTION
Preserving the invariant in MDict: _newKeys holds all alloc_slices for the keys of _map.