### PR TITLE
Preserve addresses of shared key strings on txn abort (CBL-1707)

### DIFF
--- a/Fleece/Support/ConcurrentMap.cc
+++ b/Fleece/Support/ConcurrentMap.cc
@@ -31,9 +31,31 @@ namespace fleece {
 
     /*
      This is based on the “folklore” table described in “Concurrent Hash Tables: Fast and
-     General(?)!” by Maier et al. <https://arxiv.org/pdf/1601.04017.pdf>
-     However, it's simpler because we don't support deleting or modifying entries;
-     and since insertions are not very common, we use an atomic variable to store the count.
+     General(?)!” by Maier et al. <https://arxiv.org/pdf/1601.04017.pdf>. It's a pretty basic
+     open hash table with linear probing. Atomic compare-and-swap operations are used to update
+     entries, but not to read them.
+
+     It doesn't support modifying the value of an entry, simply because SharedKeys doesn't need it.
+
+     It cannot grow past its initial capacity; this is rather difficult to do in a concurrent map
+     (the paper describes how) and would add a lot of complexity ... and again, SharedKeys has a
+     fixed capacity of 2048 so it doesn't need this.
+
+     Since insertions are not very common, it's worth the expense to materialize the count in an
+     atomic integer variable, and update it on insert/delete, instead of the more complex
+     techniques used in the paper.
+
+     Maier et al state (without explanation) that, unlike ordinary open hash tables, the "folklore"
+     table cannot reuse 'tombstones' for new entries. I believe the reason is that there could be
+     incorrect results from "torn reads" -- non-atomic reads where the two fields of the Entry
+     are not consistent with each other. However, this implementation does not suffer from torn
+     reads since its Entry is only 32 bits, as opposed to two words (128 bits). So to the best
+     of my knowledge, reusing deleted entries is safe.
+
+     Still, this table does have the common problem that large numbers of tombstones degrade
+     read performance, since tombstones have to be scanned past by the `find` method just as if they
+     were occupied. The solution would be to copy the extant entries to a new table, but (as with
+     growing) this is pretty complex in a lockless concurrent table.
      */
 
 
@@ -42,6 +64,12 @@ namespace fleece {
 
     // Max fraction of table entries that should be occupied (else lookups slow down)
     static constexpr float kMaxLoad = 0.6f;
+
+
+    // Special values of Entry::keyOffset
+    static constexpr uint16_t kEmptyKeyOffset = 0,   // an empty Entry
+                              kDeletedKeyOffset = 1, // a deleted Entry
+                              kMinKeyOffset = 2;     // first actual key offset
 
 
     // Cross-platform atomic test-and-set primitive:
@@ -74,7 +102,7 @@ namespace fleece {
         
         _heap = ConcurrentArena(tableSize + stringCapacity);
         _entries = ConcurrentArenaAllocator<Entry, true>(_heap).allocate(size);
-        _keysOffset = tableSize;
+        _keysOffset = tableSize - kMinKeyOffset;
         
         postcondition(_heap.available() == stringCapacity);
     }
@@ -96,17 +124,18 @@ namespace fleece {
 
 
     int ConcurrentMap::stringBytesCapacity() const {
-        return int(_heap.capacity() - _keysOffset);
+        return int(_heap.capacity() - (_keysOffset + kMinKeyOffset));
     }
 
 
     int ConcurrentMap::stringBytesCount() const {
-        return int(_heap.allocated() - _keysOffset);
+        return int(_heap.allocated() - (_keysOffset + kMinKeyOffset));
     }
 
 
     __hot
     bool ConcurrentMap::Entry::compareAndSwap(Entry expected, Entry swapWith) {
+        static_assert(sizeof(Entry) == 4);
         return atomicCompareAndSwap(&asInt32(), expected.asInt32(), swapWith.asInt32());
     }
 
@@ -119,16 +148,16 @@ namespace fleece {
 
     __hot
     inline uint16_t ConcurrentMap::keyToOffset(const char *allocedKey) const {
-        auto off = _heap.toOffset(allocedKey);
-        assert(off >= _keysOffset && off < _keysOffset + 65535);
-        return uint16_t(off - _keysOffset + 1);
+        ptrdiff_t result = _heap.toOffset(allocedKey) - _keysOffset;
+        assert(result >= kMinKeyOffset && result <= UINT16_MAX);
+        return uint16_t(result);
     }
 
 
     __hot
     inline const char* ConcurrentMap::offsetToKey(uint16_t offset) const {
-        assert(offset > 0);
-        return (const char*)_heap.toPointer(_keysOffset + offset - 1);
+        assert(offset >= kMinKeyOffset);
+        return (const char*)_heap.toPointer(_keysOffset + offset);
     }
 
 
@@ -137,10 +166,16 @@ namespace fleece {
         assert_precondition(key);
         for (int i = indexOfHash(hash); true; i = wrap(i + 1)) {
             Entry current = _entries[i];
-            if (current.keyOffset == 0)
-                return {};
-            else if (auto keyPtr = offsetToKey(current.keyOffset); equalKeys(keyPtr, key))
-                return {slice(keyPtr, key.size), current.value};
+            switch (current.keyOffset) {
+                case kEmptyKeyOffset:
+                    return {};
+                case kDeletedKeyOffset:
+                    break;
+                default:
+                    if (auto keyPtr = offsetToKey(current.keyOffset); equalKeys(keyPtr, key))
+                        return {slice(keyPtr, key.size), current.value};
+                    break;
+            }
         }
     }
 
@@ -151,31 +186,74 @@ namespace fleece {
         const char *allocedKey = nullptr;
         int i = indexOfHash(hash);
         while (true) {
+        retry:
             Entry current = _entries[i];
-            if (current.keyOffset == 0) {
-                // Found an empty entry to store the key in. First allocate the string:
-                if (!allocedKey) {
-                    if (_count >= _capacity)
-                        return {};          // Hash table overflow
-                    allocedKey = allocKey(key);
-                    if (!allocedKey)
-                        return {};          // Key-strings overflow
-                }
-                Entry newEntry = {keyToOffset(allocedKey), value};
-                // Try to store my new entry, if another thread didn't beat me to it:
-                if (_entries[i].compareAndSwap(current, newEntry)) {
+            switch (current.keyOffset) {
+                case kEmptyKeyOffset:
+                case kDeletedKeyOffset: {
+                    // Found an empty or deleted entry to use. First allocate the string:
+                    if (!allocedKey) {
+                        if (_count >= _capacity)
+                            return {};          // Hash table overflow
+                        allocedKey = allocKey(key);
+                        if (!allocedKey)
+                            return {};          // Key-strings overflow
+                    }
+                    Entry newEntry = {keyToOffset(allocedKey), value};
+                    // Try to store my new entry, if another thread didn't beat me to it:
+                    if (_usuallyFalse(!_entries[i].compareAndSwap(current, newEntry))) {
+                        // I was beaten to it; retry (at the same index,
+                        // in case CAS was a false negative)
+                        goto retry;
+                    }
                     // Success!
                     ++_count;
                     assert(_count <= _capacity);
                     return {slice(allocedKey, key.size), value};
-                } else {
-                    // I was beaten to it; retry (at the same index, in case CAS was false positive)
-                    continue;
                 }
-            } else if (auto keyPtr = offsetToKey(current.keyOffset); equalKeys(keyPtr, key)) {
-                // Key already exists in table. Deallocate any string I allocated:
-                freeKey(allocedKey);
-                return {slice(keyPtr, key.size), current.value};
+                default:
+                    if (auto keyPtr = offsetToKey(current.keyOffset); equalKeys(keyPtr, key)) {
+                        // Key already exists in table. Deallocate any string I allocated:
+                        freeKey(allocedKey);
+                        return {slice(keyPtr, key.size), current.value};
+                    }
+                    break;
+            }
+            i = wrap(i + 1);
+        }
+    }
+
+
+    bool ConcurrentMap::remove(slice key, hash_t hash) {
+        assert_precondition(key);
+        int i = indexOfHash(hash);
+        while (true) {
+        retry:
+            Entry current = _entries[i];
+            switch (current.keyOffset) {
+                case kEmptyKeyOffset:
+                    // Not found.
+                    return false;
+                case kDeletedKeyOffset:
+                    break;
+                default:
+                    if (auto keyPtr = offsetToKey(current.keyOffset); equalKeys(keyPtr, key)) {
+                        // Found it -- now replace with a tombstone. Leave the value alone in case
+                        // a concurrent torn read sees the prior offset + new value.
+                        Entry tombstone = {kDeletedKeyOffset, current.value};
+                        if (_usuallyFalse(!_entries[i].compareAndSwap(current, tombstone))) {
+                            // I was beaten to it; retry (at the same index,
+                            // in case CAS was a false negative)
+                            goto retry;
+                        }
+                        // Success!
+                        --_count;
+                        // Freeing the key string will only do anything if it was the latest key
+                        // to be added, but it's worth a try.
+                        (void)freeKey(keyPtr);
+                        return true;
+                    }
+                    break;
             }
             i = wrap(i + 1);
         }
@@ -199,28 +277,37 @@ namespace fleece {
     __cold
     void ConcurrentMap::dump() const {
         int size = tableSize();
-        int realCount = 0, totalDistance = 0, maxDistance = 0;
+        int realCount = 0, tombstones = 0, totalDistance = 0, maxDistance = 0;
         for (int i = 0; i < size; i++) {
-            if (auto e = _entries[i]; e.keyOffset != 0) {
-                ++realCount;
-                auto keyPtr = offsetToKey(e.keyOffset);
-                hash_t hash = hashCode(slice(keyPtr));
-                int bestIndex = indexOfHash(hash);
-                printf("%6d: %-10s = %08x [%5d]", i, keyPtr, hash, bestIndex);
-                if (i != bestIndex) {
-                    if (bestIndex > i)
-                        bestIndex -= size;
-                    auto distance = i - bestIndex;
-                    printf(" +%d", distance);
-                    totalDistance += distance;
-                    maxDistance = max(maxDistance, distance);
+            auto e = _entries[i];
+            switch (e.keyOffset) {
+                case kEmptyKeyOffset:
+                    printf("%6d\n", i);
+                    break;
+                case kDeletedKeyOffset:
+                    ++tombstones;
+                    printf("%6d xxx\n", i);
+                    break;
+                default: {
+                    ++realCount;
+                    auto keyPtr = offsetToKey(e.keyOffset);
+                    hash_t hash = hashCode(slice(keyPtr));
+                    int bestIndex = indexOfHash(hash);
+                    printf("%6d: %-10s = %08x [%5d]", i, keyPtr, hash, bestIndex);
+                    if (i != bestIndex) {
+                        if (bestIndex > i)
+                            bestIndex -= size;
+                        auto distance = i - bestIndex;
+                        printf(" +%d", distance);
+                        totalDistance += distance;
+                        maxDistance = max(maxDistance, distance);
+                    }
+                    printf("\n");
                 }
-                printf("\n");
-            } else {
-                printf("%6d\n", i);
             }
         }
-        printf("Occupancy = %d / %d (%.0f%%)\n", realCount, size, realCount/double(size)*100.0);
+        printf("Occupancy = %d / %d (%.0f%%), with %d tombstones\n",
+               realCount, size, realCount/double(size)*100.0, tombstones);
         printf("Average probes = %.1f, max probes = %d\n",
                1.0 + (totalDistance / (double)realCount), maxDistance);
     }

--- a/Fleece/Support/ConcurrentMap.hh
+++ b/Fleece/Support/ConcurrentMap.hh
@@ -13,20 +13,27 @@
 namespace fleece {
 
     /** A lockless concurrent hash table that maps strings to 16-bit ints.
-        Does not support modifications or deletions. Intended for use by SharedKeys. */
+        Intended for use by SharedKeys. */
     class ConcurrentMap {
         public:
         static constexpr int kMaxCapacity = 0x7FFF;
         static constexpr int kMaxStringCapacity = 0x10000;
 
+        /** Constructs a ConcurrentMap. The capacity is fixed.
+            @param capacity  The number of keys it needs to hold. Cannot exceed kMaxCapacity.
+            @param stringCapacity  Maximum total size in bytes of all keys, including one byte per
+                                   key as a separator. Cannot exceed kMaxStringCapacity.
+                                   If 0 or omitted, value is `17 * capacity`. */
         ConcurrentMap(int capacity, int stringCapacity =0);
 
         // Move cannot be concurrent with find or insert calls!
         ConcurrentMap(ConcurrentMap&&);
         ConcurrentMap& operator=(ConcurrentMap&&);
 
+        /// The type of value associated with a key.
         using value_t = uint16_t;
 
+        /// The hash code of a key.
         enum class hash_t : uint32_t { };
 
         /** Computes the hash code of a key. This code can be passed to alternate versions of the
@@ -44,13 +51,14 @@ namespace fleece {
             uint16_t value;
         };
 
-        /** Looks up the key. Returns the value, as well as the key in memory owned by the map.
+        /** Looks up the key. Returns the value, as well as the key in memory owned by the map
+            (which is guaranteed to remain valid until the entry is removed or the map destructed.)
             If the key is not found, returns a result with an empty slice for the key. */
         result find(slice key) const noexcept FLPURE    {return find(key, hashCode(key));}
         result find(slice key, hash_t) const noexcept FLPURE;
 
-        /** Inserts a value for a key. Returns the value, as well as a new copy of the key in memory owned
-            by the map.
+        /** Inserts a value for a key. Returns the value, as well as a new copy of the key in
+            memory owned by the map.
             If the key already exists, the existing value is not changed, and the existing value is
             returned as well as the managed copy of the key (as from `find`.)
             If the hash table or key storage is full and the key can't be inserted, returns an empty
@@ -58,12 +66,21 @@ namespace fleece {
         result insert(slice key, value_t value)         {return insert(key, value, hashCode(key));}
         result insert(slice key, value_t value, hash_t);
 
+        /** Removes the value for a key. Returns true if removed, false if not found.
+            \note  The space occupied by the key string can only be recovered if this was the
+                   last key added, so when removing multiple keys it's best to go in reverse
+                   chronological order. */
+        bool remove(slice key)                          {return remove(key, hashCode(key));}
+        bool remove(slice key, hash_t hash);
+
+        /** Writes all the table entries, plus statistics, to stdout. */
         void dump() const;
 
     private:
+        // Hash table entry (32 bits).
         struct Entry {
-            uint16_t keyOffset;               // 1 + offset of key from _keysOffset, or 0 if empty
-            uint16_t value;                   // value of key
+            uint16_t keyOffset;     // offset of key from _keysOffset, or 0 if empty, 1 if deleted
+            uint16_t value;         // value associated with key
 
             uint32_t& asInt32()                 {return *(uint32_t*)this;}
             bool compareAndSwap(Entry expected, Entry swapWith);

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -212,6 +212,9 @@ TEST_CASE("Hash distribution") {
 }
 
 
+#pragma mark - CONCURRENT MAP:
+
+
 TEST_CASE("ConcurrentMap basic", "[ConcurrentMap]") {
     ConcurrentMap map(2048);
     cout << "table size = " << map.tableSize() << ", capacity = " << map.capacity()
@@ -235,6 +238,11 @@ TEST_CASE("ConcurrentMap basic", "[ConcurrentMap]") {
     CHECK(found.key == apple.key);
     CHECK(found.value == apple.value);
 
+    // nonexistent key:
+    found = map.find("durian");
+    CHECK(!found.key);
+    CHECK(!map.remove("durian"));
+
     for (int pass = 1; pass <= 2; ++pass) { // insert on 1st pass, read on 2nd
         for (uint16_t i = 0; i < 2046; ++i) {
             char keybuf[10];
@@ -245,10 +253,15 @@ TEST_CASE("ConcurrentMap basic", "[ConcurrentMap]") {
         }
     }
 
+    // now remove a key:
+    CHECK(map.remove("apple"));
+    found = map.find("apple");
+    CHECK(!found.key);
+
     cout << "Afterwards: count = " << map.count()
          << ", string bytes used = " << map.stringBytesCount() << '\n';
 
-    CHECK(map.count() == 2047);
+    CHECK(map.count() == 2046);
     CHECK(map.stringBytesCount() > 0);
 
     //map.dump();
@@ -270,9 +283,12 @@ TEST_CASE("ConcurrentMap concurrency", "[ConcurrentMap]") {
         keys.push_back(keybuf);
     }
 
+    // Note: cannot use CHECK or REQUIRE in lambdas below because the Catch test framework is not
+    //       thread-safe :(  Thus `assert` is used instead.
+
     auto reader = [&](int step) {
         size_t index = random() % kSize;
-        for (int n = 0; n < kSize; n++) {
+        for (int n = 0; n < 2 * kSize; n++) {
             auto e = map.find(keys[index].c_str());
             if (e.key) {
                 assert(e.key == keys[index].c_str());
@@ -283,13 +299,19 @@ TEST_CASE("ConcurrentMap concurrency", "[ConcurrentMap]") {
     };
 
     auto writer = [&](int step) { // step must be coprime with kSize
-        unsigned index = (unsigned)random() % kSize;
+        unsigned const startIndex = (unsigned)random() % kSize;
+        auto index = startIndex;
         for (int n = 0; n < kSize; n++) {
             auto value = uint16_t(index & 0xFFFF);
             auto e = map.insert(keys[index].c_str(), value);
             assert(e.key != nullslice);
             assert(e.key == keys[index].c_str());
             assert(e.value == value);
+            index = (index + step) % kSize;
+        }
+        index = startIndex;
+        for (int n = 0; n < kSize; n++) {
+            map.remove(keys[index].c_str());
             index = (index + step) % kSize;
         }
     };
@@ -304,8 +326,11 @@ TEST_CASE("ConcurrentMap concurrency", "[ConcurrentMap]") {
     f3.wait();
     f4.wait();
 
-    CHECK(map.count() == kSize);
+    CHECK(map.count() == 0);
 }
+
+
+#pragma mark - SMALLVECTOR:
 
 
 TEST_CASE("SmallVector, small", "[SmallVector]") {


### PR DESCRIPTION
PersistentSharedKeys::revert() was creating a new ConcurrentMap to store the remaining keys, since ConcurrentMap didn't support deletion. Unfortunately that meant that the existing keys had different addresses afterwards, invalidating anything that was holding onto them as slices. That included the Obj-C mutable-Fleece classes.

Fixed this by implementing ConcurrentMap::remove(), which can remove keys in place, removing the need to create a new map.

Recommended reading: Section 4 of ["Concurrent Hash Tables: Fast and General(?)!"](https://arxiv.org/pdf/1601.04017.pdf)

CBL-1707