### PR TITLE
CBL-1760: add constructor for easily converting FLValue to MArray/MDict

### DIFF
--- a/Fleece/Integration/MArray.hh
+++ b/Fleece/Integration/MArray.hh
@@ -32,6 +32,14 @@ namespace fleece {
 
         /** Constructs an empty MArray not connected to any existing Fleece Array. */
         MArray() :MCollection() { }
+        
+        /** Constructs an MArray with value and context, setJSON uses this to create a MArray */
+        MArray(MContext *context, Value value, bool isMutable)
+        : MCollection(context, isMutable)
+        ,_array(value.asArray())
+        {
+            _vec.resize(_array.count());
+        }
 
         /** Constructs an MArray that shadows an Array stored in `mv` and contained in `parent`.
             This is what you'd call from MValue::toNative. */

--- a/Fleece/Integration/MDict.hh
+++ b/Fleece/Integration/MDict.hh
@@ -36,6 +36,15 @@ namespace fleece {
 
         /** Constructs an empty MDict not connected to any existing Fleece Dict. */
         MDict() :MCollection() { }
+        
+        /** Constructs a MDict with value and context, setJSON uses this to create a MDict */
+        MDict(MContext *context, Value value, bool isMutable)
+        : MCollection(context, isMutable)
+        ,_dict(value.asDict())
+        {
+            _count(_dict.count());
+            _map.reserve(5);
+        }
 
         /** Constructs an MDict that shadows a Dict stored in `mv` and contained in `parent`.
             This is what you'd call from MValue::toNative. */


### PR DESCRIPTION
* When creating the CBLMutableArray, CBLMutableDictionary from SetJSON, without database/c4doc. Currently we are iterating through the list and converting each objects. 
```
FLEncoder_ConvertJSON(enc, JSONString);
FLSliceResult res = FLEncoder_Finish(enc);
FLValue val = FLValue_FromData(FLSlice(res), kFLTrusted);

// -- we are optimizing from here
// old way
FLArray array = FLValue_AsArray(result);
_array.clear();
uint count = FLArray_Count(array);
for (uint i = 0; i < count; i++) {
    id value = FLValue_GetNSObject(FLArray_Get(array, (uint32_t)i), nil);
    _array.append([value cbl_toCBLObject]);
}
```

* a better approach without iterating: FLValue -> MRoot -> MArray
```
_root.reset(new MRoot<id>(new cbl::DocContext(), val, true));
CBLMutableArray* array = _root->asNative();
_array.initAsCopyOf(*(MArray<id>*) array.fl_collection, true);
```

* While doing so, looked at a way to directly convert the FLValue -> MArray/MDict; Which looks more cleaner. 
```
MArray<id> mArray(new cbl::DocContext(), result, true);
_array.initAsCopyOf(mArray, true);
```

Last one is same as creating an MRoot, but directly setting the `MCollection(context, isMutable)` from MArray. 

related: https://github.com/couchbase/couchbase-lite-ios/pull/2842

