### PR TITLE
Fixed crash in alloc_slice::uncopiedNSData()

### DIFF
--- a/ObjC/slice+CoreFoundation.cc
+++ b/ObjC/slice+CoreFoundation.cc
@@ -65,9 +65,19 @@ namespace fleece {
         static CFAllocatorContext context = {
             .version = 0,
             .info = nullptr,
-            .retain = [](const void *p) -> const void* { alloc_slice::retain(slice(p,1)); return p; },
-            .release = [](const void *p) -> void        { alloc_slice::release(slice(p,1)); },
-            .deallocate = [](void *p, void *info) -> void   { alloc_slice::release(slice(p,1)); },
+            .retain = [](const void *p) -> const void* {
+                if (p)
+                    alloc_slice::retain(slice(p,1));
+                return p;
+            },
+            .release = [](const void *p) -> void {
+                if (p)
+                    alloc_slice::release(slice(p,1));
+            },
+            .deallocate = [](void *p, void *info) -> void {
+                if (p)
+                    alloc_slice::release(slice(p,1));
+            },
         };
         static CFAllocatorRef kAllocator = CFAllocatorCreate(nullptr, &context);
         return kAllocator;

--- a/Tests/ObjCTests.mm
+++ b/Tests/ObjCTests.mm
@@ -23,14 +23,31 @@
 using namespace fleece::impl;
 
 static void checkIt(id obj, const char* json) {
-    Encoder enc;
-    enc.writeObjC(obj);
-    enc.end();
-    auto result = enc.finish();
-    auto v = Value::fromData(result);
-    REQUIRE(v != nullptr);
-    REQUIRE(v->toJSON() == alloc_slice(json));
-    REQUIRE([v->toNSObject() isEqual: obj]);
+    @autoreleasepool {
+        Encoder enc;
+        enc.writeObjC(obj);
+        enc.end();
+        auto result = enc.finish();
+        auto v = Value::fromData(result);
+        REQUIRE(v != nullptr);
+        REQUIRE(v->toJSON() == alloc_slice(json));
+        REQUIRE([v->toNSObject() isEqual: obj]);
+    }
+}
+
+
+TEST_CASE("Slice NSData") {
+    @autoreleasepool {
+        slice str = "Hi, I am a string";
+        NSData *data;
+        {
+            alloc_slice s(str);
+            data = s.uncopiedNSData();
+            // `s` is released, but `data` should have its own reference to the heap block...
+        }
+        CHECK(data.length == str.size);
+        CHECK(slice(data) == str);
+    }
 }
 
 


### PR DESCRIPTION
The CoreFoundation callbacks needed to gracefully ignore NULL params.
Added a unit test, verified that it reproduced the reported crash, and that it no longer crashes.
Fixes CBL-1988