### PR TITLE
Fixed Android 11 incompatibility with ValueSlot ptr tagging

### DIFF
--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -37,7 +37,7 @@ namespace fleece { namespace impl {
 
 
     ValueSlot::ValueSlot(Null)
-    :_pointerTag(0xFF)
+    :_tag(kInlineTag)
     {
         _inlineVal[0] = ((kSpecialTag << 4) | kSpecialValueNull);
     }
@@ -100,6 +100,8 @@ namespace fleece { namespace impl {
 
 
     void ValueSlot::setPointer(const Value *v) {
+        // This is a requirement for the tagging to work (see description in header):
+        precondition((intptr_t(v) & 0xFF) != kInlineTag);
         precondition(v != nullptr);
         if (_usuallyFalse(v == pointer()))
             return;
@@ -111,7 +113,7 @@ namespace fleece { namespace impl {
 
     void ValueSlot::setInline(internal::tags valueTag, int tiny) {
         releaseValue();
-        _pointerTag = 0xFF;
+        _tag = kInlineTag;
         _inlineVal[0] = uint8_t((valueTag << 4) | tiny);
     }
 
@@ -187,7 +189,7 @@ namespace fleece { namespace impl {
             if (size <= kInlineCapacity) {
                 // Copy value inline if it's small enough
                 releaseValue();
-                _pointerTag = 0xFF;
+                _tag = kInlineTag;
                 memcpy(&_inlineVal, v, size);
                 return;
             }


### PR DESCRIPTION
The prior size optimization in ValueSlot used the high byte of the
`_pointer` field to distinguish between an actual pointer and an
inline 7-bit Value; it assumed if the upper byte is zero then it's a
pointer.

This isn't true anymore in Android: "Starting in Android 11, for 64-
bit processes, all heap allocations have an implementation defined tag
set in the top byte of the pointer on devices with kernel support for
ARM Top-byte Ignore (TBI)."

Switched to using the _low_ byte as a tag, with a value of 0xFF
denoting inline, and anything else being a pointer. This works because
any Value* we store there must have at least one zero bit in the
LSB; see the comment in ValueSlot.hh for details.