### PR TITLE
Fixed leak-producing FLSliceResult -> alloc_slice conversions

### DIFF
--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -287,6 +287,7 @@ namespace fleece {
         // FLSlice interoperability:
         constexpr slice(const FLSlice &s) noexcept STEPOVER           :pure_slice(s.buf,s.size) { }
         inline explicit operator FLSliceResult () const noexcept;
+        explicit slice(const FLSliceResult &sr) STEPOVER            :pure_slice(sr.buf, sr.size) { }
         slice& operator= (FLHeapSlice s) noexcept           {set(s.buf, s.size); return *this;} // disambiguation
 
 #ifdef SLICE_SUPPORTS_STRING_VIEW
@@ -388,8 +389,8 @@ namespace fleece {
         inline void shorten(size_t s);
 
         // FLSliceResult interoperability:
-        alloc_slice(const FLSliceResult &s) noexcept STEPOVER :pure_slice(s.buf, s.size) {retain();}
-        explicit alloc_slice(FLSliceResult &&sr) noexcept STEPOVER  :pure_slice(sr.buf, sr.size) { }
+        explicit alloc_slice(const FLSliceResult &s) noexcept STEPOVER :pure_slice(s.buf, s.size) {retain();}
+        alloc_slice(FLSliceResult &&sr) noexcept STEPOVER  :pure_slice(sr.buf, sr.size) { }
         explicit operator FLSliceResult () & noexcept       {retain(); return {(void*)buf, size};}
         explicit operator FLSliceResult () && noexcept      {FLSliceResult r {(void*)buf, size};
                                                              set(nullptr, 0); return r;}


### PR DESCRIPTION
The constructor `alloc_slice(FLSliceResult &&)` has been marked `explicit` since
commit 777db2 on Feb 25. I don't know why that change was made. Jianmin just
discovered that our many implicit conversions from an FLSliceResult rvalue to
an alloc_slice are now leaking as a result -- they now call the _lvalue_
reference version, which does not release the FLSliceResult.

I removed `explicit` from the rvalue-ref version and added it to the lvalue-ref
version. This required only two small source changes in LiteCore, and the
LiteCore tests still pass.

(The `explicit slice(const FLSliceResult&)` constructor I added is to fix some
conversions in LiteCore that were apparently using alloc_slice as an
intermediate, and broke when I made the lvalue version explicit.)