### PR TITLE
Fix buffer overflow when decoding base64 string

### DIFF
--- a/Fleece/Support/Base64.cc
+++ b/Fleece/Support/Base64.cc
@@ -25,6 +25,7 @@ namespace fleece { namespace base64 {
 
     std::string encode(slice data) {
         std::string str;
+        // 3 bytes -> 4 chars : ceil(data.size / 3) * 4
         size_t strLen = ((data.size + 2) / 3) * 4;
         str.resize(strLen);
         char *dst = &str[0];
@@ -39,7 +40,10 @@ namespace fleece { namespace base64 {
 
 
     alloc_slice decode(slice b64) {
-        size_t expectedLen = (b64.size + 3) / 4 * 3;
+        // 4 chars -> 3 bytes : (ceil(b64.size / 4) * 3) + 1
+        // One extra buffer required by the libb64 decoder when reporting ending decoding position
+        // for the case that the buffer size is the same as the output size.
+        size_t expectedLen = ((b64.size + 3) / 4 * 3) + 1;
         alloc_slice result(expectedLen);
         slice decoded = decode(b64, (void*)result.buf, result.size);
         if (decoded.size == 0)
@@ -51,7 +55,7 @@ namespace fleece { namespace base64 {
 
 
     slice decode(slice b64, void *outputBuffer, size_t bufferSize) noexcept {
-        size_t expectedLen = (b64.size + 3) / 4 * 3;
+        size_t expectedLen = ((b64.size + 3) / 4 * 3) + 1;
         if (expectedLen > bufferSize)
             return nullslice;
         ::base64::decoder dec;

--- a/Fleece/Support/Base64.cc
+++ b/Fleece/Support/Base64.cc
@@ -40,10 +40,8 @@ namespace fleece { namespace base64 {
 
 
     alloc_slice decode(slice b64) {
-        // 4 chars -> 3 bytes : (ceil(b64.size / 4) * 3) + 1
-        // One extra buffer required by the libb64 decoder when reporting ending decoding position
-        // for the case that the buffer size is the same as the output size.
-        size_t expectedLen = ((b64.size + 3) / 4 * 3) + 1;
+        // 4 chars -> 3 bytes : ceil(b64.size / 4) * 3
+        size_t expectedLen = ((b64.size + 3) / 4 * 3);
         alloc_slice result(expectedLen);
         slice decoded = decode(b64, (void*)result.buf, result.size);
         if (decoded.size == 0)
@@ -55,7 +53,7 @@ namespace fleece { namespace base64 {
 
 
     slice decode(slice b64, void *outputBuffer, size_t bufferSize) noexcept {
-        size_t expectedLen = ((b64.size + 3) / 4 * 3) + 1;
+        size_t expectedLen = (b64.size + 3) / 4 * 3;
         if (expectedLen > bufferSize)
             return nullslice;
         ::base64::decoder dec;

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -22,6 +22,7 @@
 #include "Bitmap.hh"
 #include "TempArray.hh"
 #include "sliceIO.hh"
+#include "Base64.hh"
 #include <iostream>
 #include <future>
 
@@ -315,4 +316,17 @@ TEST_CASE("SmallVector, big", "[SmallVector]") {
     CHECK(movedStrings[0] == "string 1"_sl);
     CHECK(movedStrings[1] == "string 2"_sl);
     CHECK(movedStrings[2] == "string 3"_sl);
+}
+
+
+TEST_CASE("Base64 encode and decode", "[Base64]") {
+    vector<string> inputs = {"a", "ab", "abc", "abcd", "abcde"};
+    vector<string> encodingResults = {"YQ==", "YWI=", "YWJj", "YWJjZA==", "YWJjZGU="};
+    int i = 0;
+    for (auto in : inputs) {
+        auto encoded = base64::encode(slice(in));
+        CHECK(encoded == encodingResults[i++]);
+        auto decoded = base64::decode(slice(encoded));
+        CHECK(decoded == in);
+    }
 }

--- a/vendor/libb64/cdecode.c
+++ b/vendor/libb64/cdecode.c
@@ -38,7 +38,8 @@ size_t base64_decode_block(const uint8_t* code_in, const size_t length_in, void*
 				if (codechar == code_in+length_in)
 				{
 					state_in->step = step_a;
-					state_in->plainchar = *plainchar;
+					// CBL-2264: Point back to zero instead of pointing beypond the allocated buffer
+					state_in->plainchar = 0;
 					return plainchar - (uint8_t*)plaintext_out;
 				}
 				fragment = base64_decode_value(*codechar++);


### PR DESCRIPTION
Add one extra bytes to the output buffer as required by the decoder when it reports the ending position for the case that the buffer size is exactly the same size as the output.

CBL-2264