### PR TITLE
FLDoc: Added get/set associated pointer API

### DIFF
--- a/API/fleece/Fleece.h
+++ b/API/fleece/Fleece.h
@@ -124,8 +124,34 @@ extern "C" {
     /** Returns the FLSharedKeys used by this FLDoc, as specified when it was created. */
     FLSharedKeys FLDoc_GetSharedKeys(FLDoc) FLAPI FLPURE;
 
+    /** Associates an arbitrary pointer value with a document, and thus its contained values.
+        Allows client code to associate its own pointer with this FLDoc and its Values,
+        which can later be retrieved with \ref FLDoc_GetAssociated.
+        For example, this could be a pointer to an `app::Document` object, of which this Doc's
+        root FLDict is its properties. You would store it by calling
+        `FLDoc_SetAssociated(doc, myDoc, "app::Document");`.
+        @param doc  The FLDoc to store a pointer in.
+        @param pointer  The pointer to store in the FLDoc.
+        @param type  A C string literal identifying the type. This is used to avoid collisions
+                     with unrelated code that might try to store a different type of value.
+        @return  True if the pointer was stored, false if a pointer of a different type is
+                 already stored.
+        @warning  Be sure to clear this before the associated object is freed/invalidated!
+        @warning  This function is not thread-safe. Do not concurrently get & set objects. */
+    bool FLDoc_SetAssociated(FLDoc doc, void *pointer, const char *type) FLAPI;
+
+    /** Returns the pointer associated with the document. You can use this together with
+        \ref FLValue_FindDoc to associate your own object with Fleece values, for instance to find
+        your object that "owns" a value:
+        `myDoc = (app::Document*)FLDoc_GetAssociated(FLValue_FindDoc(val), "app::Document");`.
+        @param doc  The FLDoc to get a pointer from.
+        @param type  The type of object expected, i.e. the same string literal passed to
+                     \ref FLDoc_SetAssociated.
+        @return  The associated pointer of that type, if any. */
+    void* FLDoc_GetAssociated(FLDoc doc, const char *type) FLAPI FLPURE;
+
     /** Looks up the Doc containing the Value, or NULL if the Value was created without a Doc.
-        Caller must release the FLDoc reference!! */
+        @note Caller must release the FLDoc reference!! */
     FLDoc FLValue_FindDoc(FLValue) FLAPI FLPURE;
 
 

--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -401,6 +401,10 @@ namespace fleece {
         operator FLDoc() const                      {return _doc;}
         FLDoc detach()                              {auto d = _doc; _doc = nullptr; return d;}
 
+        static Doc containing(Value v)              {return Doc(FLValue_FindDoc(v), false);}
+        bool setAssociated(void *p, const char *t)  {return FLDoc_SetAssociated(_doc, p, t);}
+        void* associated(const char *type) const    {return FLDoc_GetAssociated(_doc, type);}
+
     private:
         friend class Value;
         explicit Doc(FLValue v)                     :_doc(FLValue_FindDoc(v)) { }

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -737,6 +737,14 @@ FLSliceResult FLDoc_GetAllocedData(FLDoc doc) FLAPI {
     return doc ? toSliceResult(doc->allocedData()) : FLSliceResult{};
 }
 
+void* FLDoc_GetAssociated(FLDoc doc, const char *type) FLAPI {
+    return doc ? doc->getAssociated(type) : nullptr;
+}
+
+bool FLDoc_SetAssociated(FLDoc doc, void *pointer, const char *type) FLAPI {
+    return doc && const_cast<Doc*>(doc)->setAssociated(pointer, type);
+}
+
 
 #pragma mark - DELTA COMPRESSION
 

--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -306,6 +306,20 @@ namespace fleece { namespace impl {
         return RetainedConst<Doc>((const Doc*)scope);
     }
 
+
+    bool Doc::setAssociated(void *pointer, const char *type) {
+        if (_associatedType && type && (_associatedType != type))
+            return false;
+        _associatedPointer = pointer;
+        _associatedType = type;
+        return true;
+    }
+
+    void* Doc::getAssociated(const char *type) const {
+        return (type == _associatedType || type == nullptr) ? _associatedPointer : nullptr;
+    }
+
+
 } }
 
 

--- a/Fleece/Core/Doc.hh
+++ b/Fleece/Core/Doc.hh
@@ -109,6 +109,28 @@ namespace fleece { namespace impl {
         const Dict* asDict() const FLPURE              {return _root ? _root->asDict() : nullptr;}
         const Array* asArray() const FLPURE            {return _root ? _root->asArray() : nullptr;}
 
+        /// Allows client code to associate its own pointer with this Doc and its Values,
+        /// which can later be retrieved with \ref getAssociated.
+        /// For example, this could be a pointer to an `app::Document` object, of which this Doc's
+        /// root Dict is its properties. You would store it by calling
+        /// `doc->setAssociatedObject(appDocument, "app::Document")`.
+        /// @param pointer  The pointer to store in this Doc.
+        /// @param type  A C string literal identifying the type. This is used to avoid collisions
+        ///              with unrelated code that might try to store a different type of value.
+        /// @return  True if the pointer was stored, false if a pointer of a different type is
+        ///          already stored.
+        /// @warning  Be sure to clear this before the associated object is freed/invalidated!
+        /// @warning  This method is not thread-safe. Do not concurrently get & set objects.
+        bool setAssociated(void *pointer, const char *type);
+
+        /// Returns a pointer previously stored in this Doc by \ref setAssociated.
+        /// For example, you would look up an `app::Document` object by calliing
+        /// `(app::Document*)Doc::containing(value)->associatedObject("app::Document")`.
+        /// @param type  The type of object expected, i.e. the same string literal passed to the
+        ///              \ref setAssociatedObject method.
+        /// @return  The associated pointer of that type, if any.
+        void* getAssociated(const char *type) const;
+
     protected:
         virtual ~Doc() =default;
 
@@ -117,6 +139,8 @@ namespace fleece { namespace impl {
 
         const Value*        _root {nullptr};            // The root object of the Fleece
         RetainedConst<Doc>  _parent;
+        void*               _associatedPointer {nullptr};
+        const char*         _associatedType {nullptr};
     };
 
 } }


### PR DESCRIPTION
This provides a reasonably type-safe way to associate a client object with a Fleece `Doc` (`FLDoc`), and thereby with any Value.

For details see the doc-comments in Fleece.h.

This is for use by Couchbase Lite C, for looking up a CBLBlob object given an FLDict in a query result set.