### PR TITLE
Fix string comparison failed on Windows under debug mode

### DIFF
--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -326,7 +326,7 @@ namespace fleece { namespace impl {
 
 
     bool Doc::setAssociated(void *pointer, const char *type) {
-        if (_associatedType && type && (_associatedType != type))
+        if (_associatedType && type && strcmp(_associatedType, type) != 0)
             return false;
         _associatedPointer = pointer;
         _associatedType = type;
@@ -334,7 +334,11 @@ namespace fleece { namespace impl {
     }
 
     void* Doc::getAssociated(const char *type) const {
-        return (type == _associatedType || type == nullptr) ? _associatedPointer : nullptr;
+        if (type == _associatedType || type == nullptr)
+            return _associatedPointer;
+        else if (_associatedType && strcmp(_associatedType, type) == 0)
+            return _associatedPointer;
+        return nullptr;
     }
 
 


### PR DESCRIPTION
* Windows debug mode is not enable string pooling optimization by default. Also it seems to be fragile to compare the pointer even though most of the case the string will be constant or literal.

* Fixed the issue to use strcmp in Doc::setAssociated() and in Doc::getAssociated() as a fallback.