### PR TITLE
CBL-2273: Export global Fleece symbols

### DIFF
--- a/API/fleece/Fleece.h
+++ b/API/fleece/Fleece.h
@@ -23,6 +23,22 @@
 #include "FLSlice.h"
 #include <stdio.h>
 
+// On Windows, FLEECE_PUBLIC marks symbols as being exported from the shared library.
+// However, this is not the whole list of things that are exported.  The API methods
+// are exported using a definition list, but it is not possible to correctly include
+// initialized global variables, so those need to be marked (both in the header and 
+// implementation) with FLEECE_PUBLIC.  See kFLNullValue below and in Fleece.cc
+// for an example.
+#if defined(_MSC_VER)
+#ifdef FLEECE_EXPORTS
+#define FLEECE_PUBLIC __declspec(dllexport)
+#else
+#define FLEECE_PUBLIC __declspec(dllimport)
+#endif
+#else
+#define FLEECE_PUBLIC
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -366,7 +382,7 @@ extern "C" {
     FLValue FLValue_NewData(FLSlice) FLAPI;
 
     /** A constant null value (not a NULL pointer!) */
-    extern const FLValue kFLNullValue;
+    FLEECE_PUBLIC extern const FLValue kFLNullValue;
 
 
     //////// ARRAY
@@ -396,7 +412,7 @@ extern "C" {
     /** Returns an value at an array index, or NULL if the index is out of range. */
     FLValue FLArray_Get(FLArray, uint32_t index) FLAPI FLPURE;
 
-    extern const FLArray kFLEmptyArray;
+    FLEECE_PUBLIC extern const FLArray kFLEmptyArray;
 
     /** \name Array iteration
         @{
@@ -599,7 +615,7 @@ while (NULL != (value = FLArrayIterator_GetValue(&iter))) {
         Returns NULL if the value is not found or if the dictionary is NULL. */
     FLValue FLDict_Get(FLDict, FLSlice keyString) FLAPI FLPURE;
 
-    extern const FLDict kFLEmptyDict;
+    FLEECE_PUBLIC extern const FLDict kFLEmptyDict;
 
     /** \name Dict iteration
          @{

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -35,9 +35,9 @@ namespace fleece { namespace impl {
 } }
 
 
-const FLValue kFLNullValue  = Value::kNullValue;
-const FLArray kFLEmptyArray = Array::kEmpty;
-const FLDict kFLEmptyDict   = Dict::kEmpty;
+FLEECE_PUBLIC const FLValue kFLNullValue  = Value::kNullValue;
+FLEECE_PUBLIC const FLArray kFLEmptyArray = Array::kEmpty;
+FLEECE_PUBLIC const FLDict kFLEmptyDict   = Dict::kEmpty;
 
 
 static FLSliceResult toSliceResult(alloc_slice &&s) {


### PR DESCRIPTION
This is a confusing situation but if compiled in a static library these directives don't have any effect directly.  The issue happens when the static library is then included in a shared library which then wants to export the symbols in its interface.  Both the declaration and definition need to be exported on Windows, but you cannot retroactively compile an exported definition.  This compiled export will carry through and apply to the eventual shared library.

NOTE: Warning, an export list will override this and make this symbol invisible again so be sure to also include it in export lists if you want to use it.