### PR TITLE
CBL-2408 : Add kFLUndefinedValue constant

### DIFF
--- a/API/fleece/Fleece.h
+++ b/API/fleece/Fleece.h
@@ -378,6 +378,9 @@ extern "C" {
     /** A constant null value (not a NULL pointer!) */
     FLEECE_PUBLIC extern const FLValue kFLNullValue;
 
+    /** A constant undefined value */
+    FLEECE_PUBLIC extern const FLValue kFLUndefinedValue;
+
 
     //////// ARRAY
 

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -30,6 +30,7 @@ namespace fleece { namespace impl {
 
 
 FLEECE_PUBLIC const FLValue kFLNullValue  = Value::kNullValue;
+FLEECE_PUBLIC const FLValue kFLUndefinedValue  = Value::kUndefinedValue;
 FLEECE_PUBLIC const FLArray kFLEmptyArray = Array::kEmpty;
 FLEECE_PUBLIC const FLDict kFLEmptyDict   = Dict::kEmpty;
 

--- a/Fleece/Support/Fleece.exp
+++ b/Fleece/Support/Fleece.exp
@@ -9,6 +9,7 @@
 #  the file licenses/APL2.txt.
 
 _kFLNullValue
+_kFLUndefinedValue
 _kFLEmptyArray
 _kFLEmptyDict
 


### PR DESCRIPTION
* Added kFLUndefinedValue constant. This is currently required by CBL-C for creating MISSING values in the Query’s result as an array.
* Added the symbol to Fleece/Support/Fleece.exp used by the XCode project.