### PR TITLE
Add Value::undefined()

### DIFF
--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -41,6 +41,7 @@ namespace fleece {
         operator FLValue() const                        {return _val;}
 
         static Value null()                             {return Value(kFLNullValue);}
+        static Value undefined()                        {return Value(kFLUndefinedValue);}
 
         inline FLValueType type() const;
         inline bool isInteger() const;

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -174,6 +174,9 @@ TEST_CASE("API Undefined", "[API]") {
 TEST_CASE("API constants", "[API]") {
     CHECK(Value::null() != nullptr);
     CHECK(Value::null().type() == kFLNull);
+    
+    CHECK(Value::undefined() != nullptr);
+    CHECK(Value::undefined().type() == kFLUndefined);
 
     CHECK((FLValue)Array::emptyArray() != nullptr);
     CHECK(Array::emptyArray().type() == kFLArray);


### PR DESCRIPTION
For parity with Value::null(), added Value::undefined().

Note: This is not required by Lithium Beta 2.