### PR TITLE
Fix `Value::isEqual` for `Value`s with `kSpecialTag`

### DIFF
--- a/Fleece/Core/Value.cc
+++ b/Fleece/Core/Value.cc
@@ -283,7 +283,7 @@ namespace fleece { namespace impl {
                 else
                     return asFloat() == v->asFloat();
             case kSpecialTag:
-                return _byte[0] == v->_byte[0];
+                return _byte[1] == v->_byte[1];
             case kStringTag:
             case kBinaryTag:
                 return getStringBytes() == v->getStringBytes();

--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -34,6 +34,7 @@ namespace fleece { namespace impl {
     :_tag(kInlineTag)
     {
         _inlineVal[0] = ((kSpecialTag << 4) | kSpecialValueNull);
+        _inlineVal[1] = 0x00;
     }
 
 
@@ -113,11 +114,13 @@ namespace fleece { namespace impl {
 
     void ValueSlot::set(Null) {
         setInline(kSpecialTag, kSpecialValueNull);
+        _inlineVal[1] = 0x00;
     }
 
 
     void ValueSlot::set(bool b) {
         setInline(kSpecialTag, b ? kSpecialValueTrue : kSpecialValueFalse);
+        _inlineVal[1] = 0x00;
     }
 
 


### PR DESCRIPTION
The added test fails without the fix in `Value::isEqual`.

Fixes #102