### PR TITLE
Initialize `Scope::_isDoc` before use

### DIFF
--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -52,30 +52,33 @@ namespace fleece { namespace impl {
     static mutex sMutex;
 
 
-    Scope::Scope(slice data, SharedKeys *sk, slice destination) noexcept
+    Scope::Scope(slice data, SharedKeys *sk, slice destination, bool isDoc) noexcept
     :_sk(sk)
     ,_externDestination(destination)
     ,_data(data)
+    ,_isDoc(isDoc)
     {
         registr();
     }
 
 
-    Scope::Scope(const alloc_slice &data, SharedKeys *sk, slice destination) noexcept
+    Scope::Scope(const alloc_slice &data, SharedKeys *sk, slice destination, bool isDoc) noexcept
     :_sk(sk)
     ,_externDestination(destination)
     ,_data(data)
     ,_alloced(data)
+    ,_isDoc(isDoc)
     {
         registr();
     }
 
 
-    Scope::Scope(const Scope &parentScope, slice subData) noexcept
+    Scope::Scope(const Scope &parentScope, slice subData, bool isDoc) noexcept
     :_sk(parentScope.sharedKeys())
     ,_externDestination(parentScope.externDestination())
     ,_data(subData)
     ,_alloced(parentScope._alloced)
+    ,_isDoc(isDoc)
     {
         // This ctor does _not_ register the data range, because the parent scope already did.
         _unregistered.test_and_set();
@@ -267,14 +270,14 @@ namespace fleece { namespace impl {
 
 
     Doc::Doc(const alloc_slice &data, Trust trust, SharedKeys *sk, slice destination) noexcept
-    :Scope(data, sk, destination)
+    :Scope(data, sk, destination, true)
     {
         init(trust);
     }
 
 
     Doc::Doc(const Doc *parentDoc, slice subData, Trust trust) noexcept
-    :Scope(*parentDoc, subData)
+    :Scope(*parentDoc, subData, true)
     ,_parent(parentDoc)                         // Ensure parent is retained
     {
         init(trust);
@@ -282,7 +285,7 @@ namespace fleece { namespace impl {
 
 
     Doc::Doc(const Scope &parentScope, slice subData, Trust trust) noexcept
-    :Scope(parentScope, subData)
+    :Scope(parentScope, subData, true)
     {
         init(trust);
     }
@@ -293,7 +296,6 @@ namespace fleece { namespace impl {
             if (!_root)
                 unregister();
         }
-        _isDoc = true;
     }
 
 

--- a/Fleece/Core/Doc.hh
+++ b/Fleece/Core/Doc.hh
@@ -29,12 +29,15 @@ namespace fleece { namespace impl {
     public:
         Scope(slice fleeceData,
               SharedKeys*,
-              slice externDestination =nullslice) noexcept;
+              slice externDestination =nullslice,
+              bool isDoc =false) noexcept;
         Scope(const alloc_slice &fleeceData,
               SharedKeys*,
-              slice externDestination =nullslice) noexcept;
+              slice externDestination =nullslice,
+              bool isDoc =false) noexcept;
         Scope(const Scope &parentScope,
-              slice subData) noexcept;
+              slice subData,
+              bool isDoc =false) noexcept;
 
         // Scope doesn't need a vtable, but it's useful for identifying subclasses, for example:
         //     auto s = dynamic_cast<const MyScope*>(Scope::containing(val));

--- a/Tests/ValueTests.cc
+++ b/Tests/ValueTests.cc
@@ -211,4 +211,11 @@ namespace fleece {
         CHECK(Doc::sharedKeys(root) == nullptr);
     }
 
+    TEST_CASE("Retain empty array contained in Doc", "[Doc]") {
+        // https://github.com/couchbaselabs/fleece/issues/113
+        Retained<Doc> doc = Doc::fromJSON("[]");
+        auto root = doc->root();
+        retain(root);
+        release(root);
+    }
 }


### PR DESCRIPTION
Fixes #113