### PR TITLE
NumConversion: Improved ParseDouble

### DIFF
--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -117,8 +117,7 @@ namespace fleece { namespace impl {
             case JSONSL_T_SPECIAL: {
                 unsigned f = state->special_flags;
                 if (f & JSONSL_SPECIALf_FLOAT || f & JSONSL_SPECIALf_EXPONENT) {
-                    char *start = (char*)&_input[state->pos_begin];
-                    _encoder.writeDouble(ParseDouble(start));
+                    writeDouble(state);
                 } else if (f & JSONSL_SPECIALf_UNSIGNED) {
                     if (_usuallyTrue(state->pos_cur - state->pos_begin < 19)) {
                         _encoder.writeUInt(state->nelem);

--- a/Fleece/Support/NumConversion.hh
+++ b/Fleece/Support/NumConversion.hh
@@ -46,9 +46,15 @@ namespace fleece {
         return ParseInteger(str, r, t);
     }
 
+
+    /// Parse `str` as a floating-point number, storing the result in `result` and returning true.
+    /// If `allowTrailing` is false, returns false if there's anything but whitespace after the
+    /// last digit.
+    bool ParseDouble(const char *str NONNULL, double &result, bool allowTrailing =false);
     
     /// Parse `str` as a floating-point number, reading as many digits as possible.
     /// (I.e. non-numeric characters after the digits are not treated as an error.)
+    /// If no digits are parseable, returns 0.0.
     double ParseDouble(const char *str NONNULL) noexcept;
 
 

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -1032,6 +1032,11 @@ public:
         CHECK(DoubleEquals(recovered, M_PI));
         CHECK(FloatEquals(recovered_f, 2.71828f));
 
+        CHECK(ParseDouble(doubleBuf, recovered));
+        CHECK(DoubleEquals(recovered, M_PI));
+        CHECK(ParseDouble(floatBuf, recovered));
+        CHECK(FloatEquals(float(recovered), 2.71828f));
+
 #ifdef _MSC_VER
         setlocale(LC_ALL, "fr-FR");
 #else

--- a/Tests/NumericTests.cc
+++ b/Tests/NumericTests.cc
@@ -30,7 +30,9 @@ static string floatStr(FLOAT n) {
     CHECK(length == strlen(str));
     if (sizeof(FLOAT) >= sizeof(double)) {
         // Test for 100% accurate double->string->double round-trip:
-        CHECK(ParseDouble(str) == n);
+        double d;
+        CHECK(ParseDouble(str, d));
+        CHECK(d == n);
     }
     return string(str);
 }


### PR DESCRIPTION
The existing ParseDouble is dumber than ParseInteger, as it doesn't do any error checking. Added a new version that does.