### PR TITLE
fix build error with clang 12.0.1

### DIFF
--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -209,7 +209,7 @@ namespace fleece {
 #   endif
 #endif
 
-        constexpr pure_slice(nullptr_t) noexcept                  :pure_slice() {}
+        constexpr pure_slice(std::nullptr_t) noexcept             :pure_slice() {}
         constexpr pure_slice(const char* str) noexcept            :buf(str), size(_strlen(str)) {}
         pure_slice(const std::string& str) noexcept               :buf(&str[0]), size(str.size()) {}
 


### PR DESCRIPTION
```
fleece/API/fleece/slice.hh:212:9: error: non-static data member cannot be constexpr; did you intend to make it const?
        constexpr pure_slice(nullptr_t) noexcept             :pure_slice() {}
        ^~~~~~~~~
        const
```