### PR TITLE
Xcode: Workaround for finding doxygen on ARM Macs

### DIFF
--- a/Fleece.xcodeproj/project.pbxproj
+++ b/Fleece.xcodeproj/project.pbxproj
@@ -1282,7 +1282,8 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/sh -e";
-			shellScript = "if which doxygen >/dev/null\nthen\n  cd $SRCROOT\n  doxygen Documentation/Doxyfile\n  doxygen Documentation/Doxyfile_C++\nfi\n";
+			shellScript = "# On ARM Macs Homebrew installs into /opt/homebrew,\n# not /usr/local. But this isn't in the PATH known\n# to shells run by Xcode; so add it:\nPATH=\"/opt/homebrew/bin:$PATH\"\nif which doxygen >/dev/null\nthen\n  which doxygen  \n  cd $SRCROOT\n  doxygen Documentation/Doxyfile\n  doxygen Documentation/Doxyfile_C++\nelse\n  echo \"doxygen not found in $PATH\"\nfi\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
On ARM Macs Homebrew installs into /opt/homebrew instead of /usr/local
(apparently so you can have both ARM-native and emulated x86 stuff?)
This directory isn't in the $PATH of shells run by Xcode, even if you
add it to ~/.bashrc.

This means if you've used Homebrew to install Doxygen on an ARM Mac,
Fleece's Build Documentation phase won't find it and does nothing.

I worked around this by updating the Build Documentation script to
prepend /opt/homebrew/bin to the PATH when it starts.