### PR TITLE
Added some date/time API functions

### DIFF
--- a/API/fleece/Fleece.h
+++ b/API/fleece/Fleece.h
@@ -75,6 +75,43 @@ extern "C" {
     } FLError;
 
 
+    //////// TIMESTAMPS
+
+
+    /** \name Timestamps
+         @{
+            Fleece does not have a native type for dates or times; like JSON, they are represented
+            as strings in ISO-8601 format, which look like "2008-08-07T05:18:51.589Z".
+
+            They can also be represented more compactly as numbers, interpreted as milliseconds
+            since the Unix epoch (midnight at January 1 1970, UTC.)
+     */
+
+    /** A point in time, expressed as milliseconds since the Unix epoch (1-1-1970 midnight UTC.) */
+    typedef int64_t FLTimestamp;
+
+    /** A value representing a missing timestamp; returned when a date cannot be parsed. */
+    #define FLTimestampNone INT64_MIN
+
+    /** Returns an FLTimestamp corresponding to the current time. */
+    FLTimestamp FLTimestamp_Now(void);
+
+    /** Formats a timestamp as a date-time string in ISO-8601 format.
+        @note  See also \ref FLEncoder_WriteDateString, which writes a timestamp to an `FLEncoder`.
+        @param timestamp  A time, given as milliseconds since the Unix epoch (1/1/1970 00:00 UTC.)
+        @param asUTC  If true, the timestamp will be given in universal time; if false, in the
+                      local timezone.
+        @return  A heap-allocated string, which you are responsible for releasing. */
+    FLStringResult FLTimestamp_ToString(FLTimestamp timestamp, bool asUTC) FLAPI;
+
+    /** Parses an ISO-8601 date-time string to a timestamp. On failure returns `FLTimestampNone`.
+        @note  See also \ref FLValue_AsTimestamp, which takes an `FLValue` and interprets numeric
+        representations as well as strings. */
+    FLTimestamp FLTimestamp_FromString(FLString str) FLAPI;
+
+    /** @} */
+
+
     //////// DOCUMENT
 
 
@@ -270,13 +307,6 @@ extern "C" {
         kFLArray,           ///< An array of values
         kFLDict             ///< A mapping of strings to values
     } FLValueType;
-
-
-    /** A timestamp, expressed as milliseconds since the Unix epoch (1-1-1970 midnight UTC.) */
-    typedef int64_t FLTimestamp;
-
-    /** A value representing a missing timestamp; returned when a date cannot be parsed. */
-    #define FLTimestampNone INT64_MIN
 
 
     /** Returns the data type of an arbitrary Value.

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -16,7 +16,9 @@
 #include "JSONDelta.hh"
 #include "fleece/Fleece.h"
 #include "JSON5.hh"
+#include "ParseDate.hh"
 #include "betterassert.hh"
+#include <chrono>
 
 
 FL_ASSUME_NONNULL_BEGIN
@@ -40,6 +42,24 @@ FLEECE_PUBLIC const FLDict kFLEmptyDict   = Dict::kEmpty;
 static FLSliceResult toSliceResult(alloc_slice &&s) {
     s.retain();
     return {(void*)s.buf, s.size};
+}
+
+
+FLTimestamp FLTimestamp_Now() {
+    return FLTimestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+
+FLStringResult FLTimestamp_ToString(FLTimestamp timestamp, bool asUTC) FLAPI {
+    char str[kFormattedISO8601DateMaxSize];
+    FormatISO8601Date(str, timestamp, asUTC);
+    return FLSliceResult_CreateWith(str, strlen(str));
+}
+
+
+FLTimestamp FLTimestamp_FromString(FLString str) FLAPI {
+    return ParseISO8601Date(str);
 }
 
 

--- a/Fleece/Support/Fleece.exp
+++ b/Fleece/Support/Fleece.exp
@@ -19,6 +19,10 @@ _FLSlice_ToCString
 __FLBuf_Retain
 __FLBuf_Release
 
+_FLTimestamp_Now
+_FLTimestamp_ToString
+_FLTimestamp_FromString
+
 _FLDoc_FromResultData
 _FLDoc_FromJSON
 _FLDoc_Release
@@ -45,6 +49,7 @@ _FLValue_AsUnsigned
 _FLValue_AsFloat
 _FLValue_AsDouble
 _FLValue_AsString
+_FLValue_AsTimestamp
 _FLValue_AsArray
 _FLValue_AsDict
 _FLValue_ToString
@@ -134,6 +139,7 @@ _FLEncoder_WriteFloat
 _FLEncoder_WriteDouble
 _FLEncoder_WriteString
 _FLEncoder_WriteData
+_FLEncoder_WriteDateString
 _FLEncoder_WriteValue
 _FLEncoder_WriteRaw
 _FLEncoder_BeginArray


### PR DESCRIPTION
I found there wasn't any way (through the public API) to store a
date-time string into a MutableDict; the only API for writing a
timestamp was on FLEncoder. There also wasn't an equivalent of
`c4_now`.

* FLTimestamp_Now(), returns the current timestamp
* FLTimestamp_ToString(), creates a date-formatted string
* FLTimestamp_FromString(), parses a date string