### PR TITLE
Fix/format literals

### DIFF
--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -192,7 +192,7 @@ namespace fleece {
         inline bool toCString(char *buf, size_t bufSize) const noexcept;
 
         // FLSlice interoperability:
-        operator FLSlice () const noexcept          {return {buf, size};}
+        constexpr operator FLSlice () const noexcept {return {buf, size};}
 
 #ifdef SLICE_SUPPORTS_STRING_VIEW
         // std::string_view interoperability:

--- a/Fleece/Core/JSONConverter.cc
+++ b/Fleece/Core/JSONConverter.cc
@@ -92,7 +92,7 @@ namespace fleece { namespace impl {
         Encoder enc;
         enc.setSharedKeys(sk);
         JSONConverter cvt(enc);
-        throwIf(!cvt.encodeJSON(slice(json)), JSONError, cvt.errorMessage());
+        throwIf(!cvt.encodeJSON(slice(json)), JSONError, "%s", cvt.errorMessage());
         return enc.finish();
     }
 

--- a/Fleece/Support/ConcurrentMap.cc
+++ b/Fleece/Support/ConcurrentMap.cc
@@ -287,7 +287,7 @@ namespace fleece {
                     auto keyPtr = offsetToKey(e.keyOffset);
                     hash_t hash = hashCode(slice(keyPtr));
                     int bestIndex = indexOfHash(hash);
-                    printf("%6d: %-10s = %08x [%5d]", i, keyPtr, hash, bestIndex);
+                    printf("%6d: %-10s = %08x [%5d]", i, keyPtr, (uint32_t)hash, bestIndex);
                     if (i != bestIndex) {
                         if (bestIndex > i)
                             bestIndex -= size;

--- a/Fleece/Support/FileUtils.hh
+++ b/Fleece/Support/FileUtils.hh
@@ -18,7 +18,7 @@ namespace fleece {
 
     static inline int checkErrno(int result, const char *msg) {
         if (_usuallyFalse(result < 0))
-            FleeceException::_throwErrno(msg);
+            FleeceException::_throwErrno("%s", msg);
         return result;
     }
 

--- a/Fleece/Support/FleeceException.hh
+++ b/Fleece/Support/FleeceException.hh
@@ -12,7 +12,7 @@
 
 #pragma once
 #include <stdexcept>
-#include "fleece/Base.h"
+#include "PlatformCompat.hh"
 #include <memory>
 
 namespace fleece {
@@ -40,8 +40,8 @@ namespace fleece {
 
         FleeceException(ErrorCode code_, int errno_, const std::string &what);
 
-        [[noreturn]] static void _throw(ErrorCode code, const char *what, ...);
-        [[noreturn]] static void _throwErrno(const char *what, ...);
+        [[noreturn]] static void _throw(ErrorCode code, const char *what, ...) __printflike(2,3);
+        [[noreturn]] static void _throwErrno(const char *what, ...) __printflike(1,2);
 
         static ErrorCode getCode(const std::exception&) noexcept;
 
@@ -50,7 +50,7 @@ namespace fleece {
         std::shared_ptr<Backtrace> backtrace;
     };
 
-    #define throwIf(BAD, ERROR, MESSAGE) \
-        if (_usuallyTrue(!(BAD))) ; else fleece::FleeceException::_throw(ERROR, MESSAGE)
+    #define throwIf(BAD, ERROR, MESSAGE, ...) \
+     if (_usuallyTrue(!(BAD))) ; else fleece::FleeceException::_throw(ERROR, MESSAGE, ##__VA_ARGS__)
 
 }

--- a/Fleece/Support/JSONEncoder.hh
+++ b/Fleece/Support/JSONEncoder.hh
@@ -113,12 +113,17 @@ namespace fleece { namespace impl {
                 _out << ',';
         }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+
         template <class T>
         void _writeInt(const char *fmt, T t) {
             comma();
             char str[32];
             _out.write(str, sprintf(str, fmt, t));
         }
+
+#pragma GCC diagnostic pop
 
         template <class T>
         void _writeFloat(T t) {

--- a/Fleece/Support/NumConversion.hh
+++ b/Fleece/Support/NumConversion.hh
@@ -93,18 +93,14 @@ namespace fleece {
                     "Invalid narrow_cast %" PRIu64 " -> %s", (uint64_t)val, typeid(Out).name());
             }
 #else
-            char message[256];
             if(::std::is_floating_point<In>::value) {
-                sprintf(message, "Invalid narrow_cast %g -> %s", (double)val, typeid(Out).name());
-                throwIf(val < std::numeric_limits<Out>::min() || val > std::numeric_limits<Out>::max(), InternalError, message);
+                throwIf(val < std::numeric_limits<Out>::min() || val > std::numeric_limits<Out>::max(), InternalError, "Invalid narrow_cast %g -> %s", (double)val, typeid(Out).name());
             } else if(::std::is_signed<In>::value) {
-                sprintf(message, "Invalid narrow_cast %" PRIi64 " -> %s", (int64_t)val, typeid(Out).name());
                 throwIf((!min_ok && val < std::numeric_limits<Out>::min()) || val > std::numeric_limits<Out>::max(),
-                    InternalError, message);
+                    InternalError, "Invalid narrow_cast %" PRIi64 " -> %s", (int64_t)val, typeid(Out).name());
             } else {
-                sprintf(message, "Invalid narrow_cast %" PRIu64 " -> %s", (uint64_t)val, typeid(Out).name());
                 throwIf((!min_ok && val < std::numeric_limits<Out>::min()) || val > std::numeric_limits<Out>::max(),
-                    InternalError, message);
+                    InternalError, "Invalid narrow_cast %" PRIu64 " -> %s", (uint64_t)val, typeid(Out).name());
             }
 #endif
             return (Out)val;

--- a/Fleece/Support/betterassert.cc
+++ b/Fleece/Support/betterassert.cc
@@ -32,6 +32,8 @@ namespace fleece {
         return file;
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 
     __cold
     static const char* log(const char *format, const char *cond, const char *fn,
@@ -48,6 +50,8 @@ namespace fleece {
             return format;
         }
     }
+
+#pragma GCC diagnostic pop
 
 
 #ifdef __cpp_exceptions

--- a/Xcode/xcconfigs/XcodeWarnings.xcconfig
+++ b/Xcode/xcconfigs/XcodeWarnings.xcconfig
@@ -6,7 +6,7 @@
 
 //BEGIN Added by Jens
 // Other Clang warnings that don't have Xcode names:
-WARNING_CFLAGS = -Woverriding-method-mismatch -Weffc++ -Wcall-to-pure-virtual-from-ctor-dtor -Wmemset-transposed-args -Wreturn-std-move -Wsizeof-pointer-div -Wdefaulted-function-deleted -Wtautological-unsigned-zero-compare -Wtautological-unsigned-enum-zero-compare -Wmismatched-tags
+WARNING_CFLAGS = -Woverriding-method-mismatch -Weffc++ -Wcall-to-pure-virtual-from-ctor-dtor -Wmemset-transposed-args -Wreturn-std-move -Wsizeof-pointer-div -Wdefaulted-function-deleted -Wtautological-unsigned-zero-compare -Wtautological-unsigned-enum-zero-compare -Wmismatched-tags -Wformat -Wformat-nonliteral -Wformat-security
 //END Added by Jens
 
 

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -85,6 +85,13 @@ function(setup_build)
         FleeceStatic PUBLIC
         -D__STDC_WANT_LIB_EXT1__=1 # For memset_s
     )
+
+    foreach(platform Fleece FleeceStatic FleeceBase)
+        set_target_properties(
+            ${platform} PROPERTIES COMPILE_FLAGS
+            "-Wformat -Wformat-nonliteral -Wformat-security"
+        )
+    endforeach()
 endfunction()
 
 function(setup_test_build)

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -41,6 +41,13 @@ function(setup_build)
         FleeceStatic PRIVATE
         __STDC_WANT_LIB_EXT1__=1 # For memset_s
     )
+
+    foreach(platform Fleece FleeceStatic FleeceBase)
+        set_target_properties(
+            ${platform} PROPERTIES COMPILE_FLAGS
+            "-Wformat=2"
+        )
+    endforeach()
 endfunction()
 
 function(setup_test_build)


### PR DESCRIPTION
- In Xcode, enabled -Wformat -Wformat-nonliteral -Wformat-security
- Fixed a couple of places that were insecurely passing non-literalstrings to format args.
- Declared "_throw" etc. as being __printflike to fix warnings.
- Disabled format security around two places where it's warning about things that are weird-but-OK .