### PR TITLE
Fix warning

### DIFF
--- a/API/fleece/FLSlice.h
+++ b/API/fleece/FLSlice.h
@@ -188,7 +188,9 @@ static inline void FLSliceResult_Release(FLSliceResult s) FLAPI {
 
 /** Type-casts a FLSliceResult to FLSlice, since C doesn't know it's a subclass. */
 static inline FLSlice FLSliceResult_AsSlice(FLSliceResult sr) {
-    return *(FLSlice*)&sr;
+    FLSlice ret;
+    memcpy(&ret, &sr, sizeof(ret));
+    return ret;
 }
 
 

--- a/API/fleece/Fleece.hh
+++ b/API/fleece/Fleece.hh
@@ -37,6 +37,7 @@ namespace fleece {
     class Value {
     public:
         Value()                                         =default;
+        Value(const Value &) noexcept                   =default;
         Value(FLValue FL_NULLABLE v)                    :_val(v) { }
         operator FLValue FL_NULLABLE () const           {return _val;}
 
@@ -117,6 +118,7 @@ namespace fleece {
     public:
         Array()                                         :Value() { }
         Array(FLArray FL_NULLABLE a)                    :Value((FLValue)a) { }
+        Array(const Array&) noexcept = default;
         operator FLArray FL_NULLABLE () const           {return (FLArray)_val;}
 
         static Array emptyArray()                       {return Array(kFLEmptyArray);}
@@ -170,6 +172,7 @@ namespace fleece {
     public:
         Dict()                                          :Value() { }
         Dict(FLDict FL_NULLABLE d)                      :Value((FLValue)d) { }
+        Dict(const Dict&) noexcept = default;
         operator FLDict FL_NULLABLE () const            {return (FLDict)_val;}
 
         static Dict emptyDict()                         {return Dict(kFLEmptyDict);}

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -116,6 +116,7 @@ namespace fleece {
         const void* FL_NULLABLE const buf;
         size_t                  const size;
 
+        pure_slice(const pure_slice &) noexcept = default;
         /// True if the slice's length is zero.
         bool empty() const noexcept FLPURE                          {return size == 0;}
 

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -146,7 +146,7 @@ namespace fleece {
         inline slice upTo(size_t offset) const noexcept FLPURE;
         inline slice from(size_t offset) const noexcept FLPURE;
 
-        inline const bool containsBytes(pure_slice bytes) const noexcept FLPURE;
+        inline bool containsBytes(pure_slice bytes) const noexcept FLPURE;
         inline slice find(pure_slice target) const noexcept FLPURE;
         inline const uint8_t* FL_NULLABLE findByte(uint8_t b) const FLPURE;
         inline const uint8_t* FL_NULLABLE findByteOrEnd(uint8_t byte) const noexcept FLPURE;
@@ -244,7 +244,7 @@ namespace fleece {
         // Calls `assert_precondition(validAddress(addr))`, then returns `addr`
         inline const void* check(const void *addr) const;
         // Calls `assert_precondition(offset <= size)`, then returns `addr`
-        inline const size_t check(size_t offset) const;
+        inline size_t check(size_t offset) const;
     };
 
 
@@ -556,7 +556,7 @@ namespace fleece {
         return addr;
     }
 
-    inline const size_t pure_slice::check(size_t offset) const {
+    inline size_t pure_slice::check(size_t offset) const {
         assert_precondition(offset <= size);
         return offset;
     }
@@ -660,7 +660,7 @@ namespace fleece {
     }
 
 
-    inline const bool pure_slice::containsBytes(pure_slice bytes) const noexcept {
+    inline bool pure_slice::containsBytes(pure_slice bytes) const noexcept {
         return bool(find(bytes));
     }
 

--- a/API/fleece/slice.hh
+++ b/API/fleece/slice.hh
@@ -430,8 +430,8 @@ namespace fleece {
         // Manual ref-count management. Use with extreme caution! You probably don't need this.
         alloc_slice& retain() noexcept                      {_FLBuf_Retain(buf); return *this;}
         inline void release() noexcept                      {_FLBuf_Release(buf);}
-        static void retain(slice s) noexcept                {((alloc_slice*)&s)->retain();}
-        static void release(slice s) noexcept               {((alloc_slice*)&s)->release();}
+        static void retain(slice s) noexcept                {static_cast<alloc_slice &>(static_cast<pure_slice &>(s)).retain();}
+        static void release(slice s) noexcept               {static_cast<alloc_slice &>(static_cast<pure_slice &>(s)).release();}
 
     private:
         void assignFrom(pure_slice s)                       {set(s.buf, s.size);}

--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -133,7 +133,7 @@ namespace fleece {
 
 
     bool Backtrace::writeTo(ostream &out) const {
-        for (int i = 0; i < _addrs.size(); ++i) {
+        for (decltype(_addrs.size()) i = 0; i < _addrs.size(); ++i) {
             if (i > 0)
                 out << '\n';
             out << '\t';
@@ -151,10 +151,10 @@ namespace fleece {
                 // Abbreviate some C++ verbosity:
                 for (auto &abbrev : kAbbreviations)
                     replace(name, abbrev.old, abbrev.nuu);
-                len = asprintf(&cstr, "%2d  %-25s %s + %zd",
-                               i, frame.library, name.c_str(), frame.offset);
+                len = asprintf(&cstr, "%2lu  %-25s %s + %zd",
+                               (unsigned long)i, frame.library, name.c_str(), frame.offset);
             } else {
-                len = asprintf(&cstr, "%2d  %p", i, _addrs[i]);
+              len = asprintf(&cstr, "%2lu  %p", (unsigned long)i, _addrs[i]);
             }
             if (len < 0)
                 return false;

--- a/Fleece/Support/ConcurrentMap.cc
+++ b/Fleece/Support/ConcurrentMap.cc
@@ -98,7 +98,7 @@ namespace fleece {
         _entries = ConcurrentArenaAllocator<Entry, true>(_heap).allocate(size);
         _keysOffset = tableSize - kMinKeyOffset;
         
-        postcondition(_heap.available() == stringCapacity);
+        postcondition(stringCapacity >= 0 && _heap.available() == size_t(stringCapacity));
     }
 
 

--- a/Fleece/Support/SmallVector.hh
+++ b/Fleece/Support/SmallVector.hh
@@ -50,7 +50,7 @@ namespace fleece {
         ~smallVector() {
             if (_size > 0) {
                 auto item = begin();
-                for (auto i = 0; i < _size; ++i)
+                for (decltype(_size) i = 0; i < _size; ++i)
                     (item++)->T::~T();
             }
         }

--- a/Fleece/Support/SmallVectorBase.hh
+++ b/Fleece/Support/SmallVectorBase.hh
@@ -34,7 +34,7 @@ namespace fleece {
 
     protected:
         smallVectorBase() noexcept                      { }
-        smallVectorBase(uint32_t cap) noexcept          :_isBig(false), _size(0), _capacity(cap) { }
+        smallVectorBase(uint32_t cap) noexcept          : _size(0), _capacity(cap), _isBig(false) { }
 
         ~smallVectorBase() {
             if (_isBig)

--- a/Fleece/Support/StringTable.cc
+++ b/Fleece/Support/StringTable.cc
@@ -244,7 +244,7 @@ namespace fleece {
                _size, _count,  _count/(double)_size*100.0);
         printf(">> Average key distance = %.2f, max = %zd\n",
                totalDistance/(double)count(), _maxDistance);
-        for (size_t i = 0; i <= _maxDistance; ++i)
+        for (decltype(_maxDistance) i = 0; i <= _maxDistance; ++i)
             printf("\t%2zd: %zd\n", i, distanceCounts[i]);
     }
 

--- a/Fleece/Support/endianness.h
+++ b/Fleece/Support/endianness.h
@@ -34,6 +34,7 @@
 #define _ENDIANNESS_H
 
 #include <stdlib.h>
+#include <string.h>
 #include <stdint.h>
 
 /* Detect platform endianness at compile time */
@@ -143,12 +144,12 @@
 static inline float _htonf(float f) {
 #ifdef __cplusplus
     static_assert(sizeof(float) == sizeof(uint32_t), "Unexpected float format");
-    uint32_t val = hton32(*(reinterpret_cast<const uint32_t *>(&f)));
-    return *(reinterpret_cast<float *>(&val));
-#else
-    uint32_t val = hton32(*(const uint32_t *)(&f));
-    return *((float *)(&val));
 #endif
+    uint32_t val;
+    memcpy(&val, &f, sizeof(val));
+    val = hton32(val);
+    memcpy(&f, &val, sizeof(f));
+    return f;
 }
 #define ntohf(x)   _htonf((x))
 #define htonf(x)   _htonf((x))
@@ -157,12 +158,12 @@ static inline float _htonf(float f) {
 static inline double _htond(double f) {
 #ifdef __cplusplus
     static_assert(sizeof(double) == sizeof(uint64_t), "Unexpected double format");
-    uint64_t val = hton64(*(reinterpret_cast<const uint64_t *>(&f)));
-    return *(reinterpret_cast<double *>(&val));
-#else
-    uint64_t val = hton64(*(const uint64_t *)(&f));
-    return *((double *)(&val));
 #endif
+    uint64_t val;
+    memcpy(&val, &f, sizeof(val));
+    val = hton64(val);
+    memcpy(&f, &val, sizeof(f));
+    return f;
 }
 #define ntohd(x)   _htond((x))
 #define htond(x)   _htond((x))

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -78,6 +78,7 @@ function(set_test_source_files_base)
         Tests/SharedKeysTests.cc
         Tests/SupportTests.cc
         Tests/ValueTests.cc
+        Tests/C_Test.c
         Experimental/KeyTree.cc
         PARENT_SCOPE
     )


### PR DESCRIPTION
Fix the most dangerous and easy to fix gcc/clang warnings.
The most of them in includes so I get them when I use fleece as external library.
For "strict aliasing violation" I confirm that my fix do not change assembly (on optimization level -O2 | /O2) for clang/gcc/msvc (amd64).