### PR TITLE
Utilize backtrace_symbols to get more information

### DIFF
--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -164,7 +164,7 @@ namespace fleece {
                 if (slash)
                     s = slash + 1;
 
-                len = asprintf(&cstr, "%2d  %s", i, s);
+                len = asprintf(&cstr, "%2lu  %s", (unsigned long)i, s);
             } else {
               len = asprintf(&cstr, "%2lu  %p", (unsigned long)i, _addrs[i]);
             }

--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -34,7 +34,7 @@
     #include <unwind.h>     // _Unwind_Backtrace(), etc.
 #endif
 
-#if defined(_LIBCPP_VERSION) || defined(__ANDROID__)
+#ifndef _MSC_VER
     #include <cxxabi.h>     // abi::__cxa_demangle()
     #define HAVE_UNMANGLE
 #endif
@@ -89,6 +89,10 @@ namespace fleece {
         return (char*)function;
     }
 
+    Backtrace::~Backtrace() {
+        free(_symbols);
+    }
+
 
     Backtrace::frameInfo Backtrace::getFrame(unsigned i) const {
         precondition(i < _addrs.size());
@@ -103,6 +107,7 @@ namespace fleece {
             if (slash)
                 frame.library = slash + 1;
         }
+
         return frame;
     }
 
@@ -153,13 +158,24 @@ namespace fleece {
                     replace(name, abbrev.old, abbrev.nuu);
                 len = asprintf(&cstr, "%2lu  %-25s %s + %zd",
                                (unsigned long)i, frame.library, name.c_str(), frame.offset);
+            } else if(_symbols) {
+                const char* s = _symbols[i];
+                const char *slash = strrchr(s, '/');
+                if (slash)
+                    s = slash + 1;
+
+                len = asprintf(&cstr, "%2d  %s", i, s);
             } else {
               len = asprintf(&cstr, "%2lu  %p", (unsigned long)i, _addrs[i]);
             }
+
             if (len < 0)
                 return false;
-            out.write(cstr, size_t(len));
-            free(cstr);
+
+            if(len > 0) {
+                out.write(cstr, size_t(len));
+                free(cstr);
+            }
 
             if (stop) {
                 out << "\n\t ... (" << (_addrs.size() - i - 1) << " more suppressed) ...";
@@ -338,6 +354,7 @@ namespace fleece {
         auto n = backtrace(&_addrs[0], skipFrames + maxFrames);
         _addrs.resize(n);
         skip(skipFrames);
+        _symbols = backtrace_symbols(_addrs.data(), _addrs.size());
     }
 
 

--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -89,10 +89,6 @@ namespace fleece {
         return (char*)function;
     }
 
-    Backtrace::~Backtrace() {
-        free(_symbols);
-    }
-
 
     Backtrace::frameInfo Backtrace::getFrame(unsigned i) const {
         precondition(i < _addrs.size());
@@ -321,6 +317,9 @@ namespace fleece {
 
 namespace fleece {
 
+    Backtrace::~Backtrace() {
+        free(_symbols);
+    }
 
     std::string Unmangle(const char *name NONNULL) {
         auto unmangled = unmangle(name);

--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -354,7 +354,9 @@ namespace fleece {
         auto n = backtrace(&_addrs[0], skipFrames + maxFrames);
         _addrs.resize(n);
         skip(skipFrames);
+#ifndef _MSC_VER
         _symbols = backtrace_symbols(_addrs.data(), _addrs.size());
+#endif
     }
 
 

--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -32,6 +32,8 @@ namespace fleece {
         /// @param maxFrames  Maximum number of frames to capture
         explicit Backtrace(unsigned skipFrames =0, unsigned maxFrames =50);
 
+        ~Backtrace();
+
         /// Removes frames from the top of the stack.
         void skip(unsigned nFrames);
 
@@ -73,6 +75,7 @@ namespace fleece {
         static void writeCrashLog(std::ostream&);
 
         std::vector<void*> _addrs;          // Array of PCs in backtrace, top first
+        char** _symbols { nullptr };
     };
 
 


### PR DESCRIPTION
During a crash, rather than just printing the PC address, use backtrace_symbols to print out a usable offset that can be later used with addr2line