### PR TITLE
Fixed implicit-conversion error from previous commits (#142)

### DIFF
--- a/Fleece/Support/Backtrace.cc
+++ b/Fleece/Support/Backtrace.cc
@@ -138,7 +138,7 @@ namespace fleece {
                 out << '\n';
             out << '\t';
             char *cstr = nullptr;
-            auto frame = getFrame(i);
+            auto frame = getFrame(unsigned(i));
             int len;
             bool stop = false;
             if (frame.function) {


### PR DESCRIPTION
Was an error in Xcode but not CMake because the latter does not
enable `-Wshorten-64-to-32`.

Fixes #142