### PR TITLE
Fixed a bad implicit conversion with mutable operator[] (#105)

### DIFF
--- a/API/fleece/Mutable.hh
+++ b/API/fleece/Mutable.hh
@@ -62,10 +62,11 @@ namespace fleece {
         void operator= (const keyref &ref)          {_coll.set(_key, ref);}
             template <class T>
         void operator= (const T &value)             {_coll.set(_key, value);}
+
+        void setNull()                              {_coll.set(_key).setNull();}
         void setData(slice value)                   {_coll.set(_key).setData(value);}
         void remove()                               {_coll.remove(_key);}
 
-        operator FLSlot FL_NONNULL ()               {return _coll.set(_key);}
     private:
         Collection _coll;
         Key _key;

--- a/API/fleece/Mutable.hh
+++ b/API/fleece/Mutable.hh
@@ -19,6 +19,9 @@ FL_ASSUME_NONNULL_BEGIN
 
 namespace fleece {
 
+    // (this is a mostly-internal type that acts as a reference to an item of a MutableArray or
+    // MutableDict, and allows a value to be stored in it. It decouples dereferencing the collection
+    // from setting the value, which simplifies the code.)
     class Slot {
     public:
         void setNull()                              {FLSlot_SetNull(_slot);}
@@ -54,6 +57,8 @@ namespace fleece {
     };
 
 
+    // (this is an internal type used to make `MutableArray` and `MutableDict`'s `operator[]`
+    // act idiomatically, supporting assignment. It's not used directly.)
     template <class Collection, class Key>
     class keyref : public Value {
     public:
@@ -215,8 +220,10 @@ namespace fleece {
     };
 
 
-    /** Equivalent to Value except that, if it holds a MutableArray/Dict, it will retain the
-        reference so it won't be freed. */
+    /** Equivalent to Value except that it retains (and releases) its contents.
+        This makes it safe for holding mutable arrays/dicts. It can also protect regular immutable
+        Values owned by a Doc from being freed, since retaining such a value causes its Doc to be
+        retained. */
     class RetainedValue : public Value {
     public:
         RetainedValue()                           =default;
@@ -251,11 +258,11 @@ namespace fleece {
         }
     };
 
-    // NOTE: The RetainedArray and RetainedDict classes are the copycats of the RetainedValue class
+    // NOTE: The RetainedArray and RetainedDict classes are copycats of the RetainedValue class
     // above. Any future changes or bug fixes to the three classes should go together.
 
-    /** Equivalent to Array except that, it holds the Array or MutableArray, and it will retain the
-        underlining FLArray object. */
+    /** Equivalent to Array except that it retains (and releases) its contents.
+        This makes it safe for holding a heap-allocated mutable array. */
     class RetainedArray : public Array {
     public:
         RetainedArray()                                 =default;
@@ -289,8 +296,8 @@ namespace fleece {
         }
     };
 
-    /** Equivalent to Dict except that, it holds the Dict or MutableDict, and it will retain the
-        underlining FLDict object. */
+    /** Equivalent to Dict except that it retains (and releases) its contents.
+        This makes it safe for holding a heap-allocated mutable dict. */
     class RetainedDict : public Dict {
     public:
         RetainedDict()                                  =default;

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -221,6 +221,15 @@ TEST_CASE("API MutableArray", "[API]") {
     CHECK(d.toJSONString() == "[1234]");
     REQUIRE(d.count() == 1);
     CHECK(d.get(0).asInt() == 1234);
+
+    d[0] = 1234;
+    CHECK(d.toJSONString() == "[1234]");
+    d[0] = false;
+    CHECK(d.toJSONString() == "[false]");
+    d[0] = "hi";
+    CHECK(d.toJSONString() == "[\"hi\"]");
+    d[0].setNull();
+    CHECK(d.toJSONString() == "[null]");
 }
 
 TEST_CASE("API MutableDict", "[API]") {
@@ -337,4 +346,22 @@ TEST_CASE("API RetainedDict", "[API]") {
     rd4 = std::move(rd5);
     REQUIRE(rd4.get("foo"_sl));
     CHECK(rd4.get("foo"_sl).asString() == "bar"_sl);
+}
+
+
+TEST_CASE("API MutableDict item bool conversion", "[API]") {
+    // From #105
+    MutableDict dict { MutableDict::newDict() };
+    dict["a_key"] = 6;
+
+    // This line converted `dict` to `keyref` and thence to `FLSlot`, which was nonnull,
+    // causing the test to pass. I've decided the FLSlot conversion operator is unnecessary;
+    // removing it fixed the issue.
+    if (dict["a_non_existent_key"]) {
+        FAIL("Key test failed");
+    }
+    if (!dict["a_key"]) {
+        FAIL("Negative key test failed");
+    }
+    CHECK(dict.toJSONString() == "{\"a_key\":6}");
 }


### PR DESCRIPTION
A boolean test of a mutable array/dict property, like
`if (dict["key"])`, would always evaluate to true; there was an
incorrect implicit conversion from `keyref` to `FLSlot` that made
the test evaluate to a non-NULL FLSlot pointer.

Removing the FLSlot conversion operator fixed it. I couldn't deduce
any need for the operator, and removing it didn't break anything in
LiteCore or CBL-C.

I did add a setNull() method, for parity with Slot.

Fixes #105