### PR TITLE
Fixed incorrect iteration of HeapDict due to key mixup

### DIFF
--- a/Fleece/Core/Dict.hh
+++ b/Fleece/Core/Dict.hh
@@ -95,6 +95,9 @@ namespace fleece { namespace impl {
         uint32_t rawCount() const noexcept FLPURE;
         const Dict* getParent() const noexcept FLPURE;
 
+        // This is like `get` but returns the key _as stored in the Dict_, either slice or int.
+        key_t encodeKey(slice keyString, SharedKeys *sharedKeys NONNULL) const noexcept;
+
         static bool isMagicParentKey(const Value *v);
         static constexpr int kMagicParentKey = -2048;
 

--- a/Fleece/Mutable/HeapDict.cc
+++ b/Fleece/Mutable/HeapDict.cc
@@ -46,9 +46,19 @@ namespace fleece { namespace impl { namespace internal {
 
 
     key_t HeapDict::encodeKey(slice key) const noexcept {
-        int intKey;
-        if (_sharedKeys && _sharedKeys->encode(key, intKey))
-            return intKey;
+        if (_sharedKeys) {
+            if (_source) {
+                // If I have a source Dict, ask it to encode the key. This ensures I'm storing the
+                // same form (int or slice) of key as it is, which is important when iterating
+                // since it affects the sort order of the keys. [CBL-2844]
+                return _source->encodeKey(key, _sharedKeys);
+            } else {
+                // Else ask the SharedKeys directly
+                int intKey;
+                if (_sharedKeys->encode(key, intKey))
+                    return intKey;
+            }
+        }
         return key;
     }
 


### PR DESCRIPTION
If a HeapDict's overlay map stores the string form of a key, but its
parent Dict uses the int form, iteration will find _both_ forms of the
key. This is obviously bad news.

Fixed this by making sure that when a new entry is added to the
overlay map, it uses the same form of key as found in the parent Dict.
(It used to just look the key up in the SharedKeys, but that's not
enough in the edge case where the in-memory SharedKeys are not up to
date and the parent Dict uses a key that's not in memory.)

CBL-2844