### PR TITLE
Issues discovered through fuzzing

### DIFF
--- a/Fleece/API_Impl/FLSlice.cc
+++ b/Fleece/API_Impl/FLSlice.cc
@@ -41,15 +41,28 @@ FL_ASSUME_NONNULL_BEGIN
 
 __hot
 bool FLSlice_Equal(FLSlice a, FLSlice b) noexcept {
-    return a.size == b.size && FLMemCmp(a.buf, b.buf, a.size) == 0;
+    if (a.size == b.size) {
+        if (a.size == 0)
+            // Check wether both slices are the nullslice or empty slices.
+            return (a.buf == nullptr) == (b.buf == nullptr);
+        else
+            return FLMemCmp(a.buf, b.buf, a.size) == 0;
+    }
+    return false;
 }
-
 
 __hot
 int FLSlice_Compare(FLSlice a, FLSlice b) noexcept {
     // Optimized for speed, not simplicity!
     if (a.size == b.size)
-        return FLMemCmp(a.buf, b.buf, a.size);
+        if (a.size == 0) {
+            // Sort the nullsice before an empty slice.
+            if ((a.buf == nullptr) == (b.buf == nullptr))
+                return 0;
+            else
+                return a.buf == nullptr ? -1 : 1;
+        } else
+            return FLMemCmp(a.buf, b.buf, a.size);
     else if (a.size < b.size) {
         int result = FLMemCmp(a.buf, b.buf, a.size);
         return result ? result : -1;

--- a/Fleece/Core/Dict.cc
+++ b/Fleece/Core/Dict.cc
@@ -309,7 +309,7 @@ namespace fleece { namespace impl {
         if (_usuallyFalse(isMutable()))
             return heapDict()->count();
         Array::impl imp(this);
-        if (_usuallyFalse(imp._count > 1 && isMagicParentKey(imp._first))) {
+        if (_usuallyFalse(imp._count >= 1 && isMagicParentKey(imp._first))) {
             // Dict has a parent; this makes counting much more expensive!
             uint32_t c = 0;
             for (iterator i(this); i; ++i)

--- a/Fleece/Core/Dict.cc
+++ b/Fleece/Core/Dict.cc
@@ -278,7 +278,7 @@ namespace fleece { namespace impl {
 
 
     __hot
-    static int compareKeys(const Value *keyToFind, const Value *key, bool wide) {
+    int compareKeys(const Value *keyToFind, const Value *key, bool wide) {
         if (wide)
             return dictImpl<true>::compareKeys(keyToFind, key);
         else

--- a/Fleece/Core/Dict.cc
+++ b/Fleece/Core/Dict.cc
@@ -65,25 +65,25 @@ namespace fleece { namespace impl {
 
         template <class KEY>
         __hot
-        const Value* finishGet(const Value *keyFound, KEY &keyToFind) const noexcept {
+        const Value* finishGet(const Value *keyFound, KEY &keyToFind, bool returnUndefined) const noexcept {
             if (keyFound) {
                 auto value = deref(next(keyFound));
-                if (_usuallyFalse(value->isUndefined()))
+                if (!returnUndefined && _usuallyFalse(value->isUndefined()))
                     value = nullptr;
                 return value;
             } else {
                 const Dict *parent = getParent();
-                return parent ? parent->get(keyToFind) : nullptr;
+                return parent ? parent->get(keyToFind, returnUndefined) : nullptr;
             }
         }
 
         __hot
-        inline const Value* getUnshared(slice keyToFind) const noexcept {
+        inline const Value* getUnshared(slice keyToFind, bool returnUndefined) const noexcept {
             auto key = search(keyToFind, [](slice target, const Value *val) {
                 countComparison();
                 return compareKeys(target, val);
             });
-            return finishGet(key, keyToFind);
+            return finishGet(key, keyToFind, returnUndefined);
         }
 
         __hot
@@ -95,25 +95,25 @@ namespace fleece { namespace impl {
         }
 
         __hot
-        inline const Value* get(int keyToFind) const noexcept {
+        inline const Value* get(int keyToFind, bool returnUndefined= false) const noexcept {
             assert_precondition(keyToFind >= 0);
-            return finishGet(search(keyToFind), keyToFind);
+            return finishGet(search(keyToFind), keyToFind, returnUndefined);
         }
 
         __hot
-        inline const Value* get(slice keyToFind, SharedKeys *sharedKeys =nullptr) const noexcept {
+        inline const Value* get(slice keyToFind, SharedKeys *sharedKeys =nullptr, bool returnUndefined= false) const noexcept {
             if (!sharedKeys && usesSharedKeys()) {
                 sharedKeys = findSharedKeys();
                 assert_precondition(sharedKeys || gDisableNecessarySharedKeysCheck);
             }
             int encoded;
             if (sharedKeys && lookupSharedKey(keyToFind, sharedKeys, encoded))
-                return get(encoded);
-            return getUnshared(keyToFind);
+                return get(encoded, returnUndefined);
+            return getUnshared(keyToFind, returnUndefined);
         }
 
         __hot
-        const Value* get(Dict::key &keyToFind) const noexcept {
+        const Value* get(Dict::key &keyToFind, bool returnUndefined= false) const noexcept {
             auto sharedKeys = keyToFind._sharedKeys;
             if (!sharedKeys && usesSharedKeys()) {
                 sharedKeys = findSharedKeys();
@@ -123,13 +123,13 @@ namespace fleece { namespace impl {
             if (_usuallyTrue(sharedKeys != nullptr)) {
                 // Look for a numeric key first:
                 if (_usuallyTrue(keyToFind._hasNumericKey))
-                    return get(keyToFind._numericKey);
+                    return get(keyToFind._numericKey, returnUndefined);
                 // Key was not registered last we checked; see if dict contains any new keys:
                 if (_usuallyFalse(_count == 0))
                     return nullptr;
                 if (lookupSharedKey(keyToFind._rawString, sharedKeys, keyToFind._numericKey)) {
                     keyToFind._hasNumericKey = true;
-                    return get(keyToFind._numericKey);
+                    return get(keyToFind._numericKey, returnUndefined);
                 }
             }
 
@@ -137,7 +137,7 @@ namespace fleece { namespace impl {
             const Value *key = findKeyByHint(keyToFind);
             if (!key)
                 key = findKeyBySearch(keyToFind);
-            return finishGet(key, keyToFind);
+            return finishGet(key, keyToFind, returnUndefined);
         }
 
         key_t encodeKey(slice keyString, SharedKeys *sharedKeys) const noexcept {
@@ -327,17 +327,26 @@ namespace fleece { namespace impl {
     }
 
     __hot
-    const Value* Dict::get(slice keyToFind) const noexcept {
+    const Value* Dict::get(slice keyToFind, bool returnUndefined) const noexcept {
         if (_usuallyFalse(isMutable()))
             return heapDict()->get(keyToFind);
         if (isWideArray())
-            return dictImpl<true>(this).get(keyToFind);
+            return dictImpl<true>(this).get(keyToFind, nullptr, returnUndefined);
         else
-            return dictImpl<false>(this).get(keyToFind);
+            return dictImpl<false>(this).get(keyToFind, nullptr, returnUndefined);
     }
 
     __hot
-    const Value* Dict::get(int keyToFind) const noexcept {
+    const Value* Dict::get(int keyToFind, bool returnUndefined) const noexcept {
+        if (_usuallyFalse(isMutable()))
+            return heapDict()->get(keyToFind);
+        else if (isWideArray())
+            return dictImpl<true>(this).get(keyToFind, returnUndefined);
+        else
+            return dictImpl<false>(this).get(keyToFind, returnUndefined);
+    }
+
+    const Value* Dict::get(key &keyToFind, bool returnUndefined) const noexcept {
         if (_usuallyFalse(isMutable()))
             return heapDict()->get(keyToFind);
         else if (isWideArray())
@@ -346,23 +355,14 @@ namespace fleece { namespace impl {
             return dictImpl<false>(this).get(keyToFind);
     }
 
-    const Value* Dict::get(key &keyToFind) const noexcept {
-        if (_usuallyFalse(isMutable()))
-            return heapDict()->get(keyToFind);
-        else if (isWideArray())
-            return dictImpl<true>(this).get(keyToFind);
-        else
-            return dictImpl<false>(this).get(keyToFind);
-    }
-
     __hot
-    const Value* Dict::get(const key_t &keyToFind) const noexcept {
+    const Value* Dict::get(const key_t &keyToFind, bool returnUndefined) const noexcept {
         if (_usuallyFalse(isMutable()))
             return heapDict()->get(keyToFind);
         else if (keyToFind.shared())
-            return get(keyToFind.asInt());
+            return get(keyToFind.asInt(), returnUndefined);
         else
-            return get(keyToFind.asString());
+            return get(keyToFind.asString(), returnUndefined);
     }
 
     key_t Dict::encodeKey(slice keyString, SharedKeys *sharedKeys) const noexcept {

--- a/Fleece/Core/Dict.hh
+++ b/Fleece/Core/Dict.hh
@@ -21,6 +21,9 @@ namespace fleece { namespace impl {
     class SharedKeys;
     class key_t;
 
+    /** Compares Dict keys in the order in which they must appear in Fleece data. */
+    int compareKeys(const Value *a, const Value *b, bool wide);
+
     /** A Value that's a dictionary/map */
     class Dict : public Value {
     public:
@@ -72,7 +75,7 @@ namespace fleece { namespace impl {
             key(const key&) =delete;
         private:
             void setSharedKeys(SharedKeys*);
-            
+
             slice const _rawString;
             SharedKeys* _sharedKeys {nullptr};
             uint32_t _hint          {0xFFFFFFFF};

--- a/Fleece/Core/Dict.hh
+++ b/Fleece/Core/Dict.hh
@@ -30,10 +30,10 @@ namespace fleece { namespace impl {
         bool empty() const noexcept FLPURE;
 
         /** Looks up the Value for a string key. */
-        const Value* get(slice keyToFind) const noexcept FLPURE;
+        const Value* get(slice keyToFind, bool returnUndefined= false) const noexcept FLPURE;
 
         /** Looks up the Value for an integer (shared) key. */
-        const Value* get(int numericKeyToFind) const noexcept FLPURE;
+        const Value* get(int numericKeyToFind, bool returnUndefined= false) const noexcept FLPURE;
 
         /** If this array is mutable, returns the equivalent MutableArray*, else returns nullptr. */
         MutableDict* asMutable() const noexcept FLPURE;
@@ -84,9 +84,9 @@ namespace fleece { namespace impl {
 
         /** Looks up the Value for a key, in a form that can cache the key's Fleece object.
             Using the Fleece object is significantly faster than a normal get. */
-        const Value* get(key&) const noexcept;
+        const Value* get(key&, bool returnUndefined= false) const noexcept;
 
-        const Value* get(const key_t&) const noexcept;
+        const Value* get(const key_t&, bool returnUndefined= false) const noexcept;
 
         constexpr Dict()  :Value(internal::kDictTag, 0, 0) { }
 

--- a/Fleece/Core/Pointer.cc
+++ b/Fleece/Core/Pointer.cc
@@ -101,10 +101,11 @@ namespace fleece { namespace impl { namespace internal {
     }
 
 
-    bool Pointer::validate(bool wide, const void *dataStart) const noexcept{
+    bool Pointer::validate(bool wide, const void *dataStart,
+                           bool checkSharedKeyExists) const noexcept{
         const void *dataEnd = this;
         const Value *target = carefulDeref(wide, dataStart, dataEnd);
-        return target && target->validate(dataStart, dataEnd);
+        return target && target->validate(dataStart, dataEnd, checkSharedKeyExists);
     }
 
 

--- a/Fleece/Core/Pointer.hh
+++ b/Fleece/Core/Pointer.hh
@@ -58,7 +58,8 @@ namespace fleece { namespace impl { namespace internal {
                                   const void* &dataEnd) const noexcept;
 
 
-        bool validate(bool wide, const void *dataStart) const noexcept FLPURE;
+        bool validate(bool wide, const void *dataStart,
+                      bool checkSharedKeyExists) const noexcept FLPURE;
 
     private:
         // Byte offset as interpreted prior to the 'extern' flag

--- a/Fleece/Core/SharedKeys.hh
+++ b/Fleece/Core/SharedKeys.hh
@@ -75,7 +75,10 @@ namespace fleece { namespace impl {
         alloc_slice stateData() const;
         void writeState(Encoder &enc) const;
 
-        /** Sets the maximum length of string that can be mapped. (Defaults to 16 bytes.) */
+        /** The maximum length of string that can be mapped. */
+        size_t maxKeyLength()                   {return _maxKeyLength;}
+
+        /** Sets maxKeyLength. (Defaults to 16 bytes.) */
         void setMaxKeyLength(size_t m)          {_maxKeyLength = m;}
 
         /** The number of stored keys. */

--- a/Fleece/Core/Value+Dump.cc
+++ b/Fleece/Core/Value+Dump.cc
@@ -253,7 +253,7 @@ namespace fleece { namespace impl {
 
 
     bool Value::dump(slice data, std::ostream &out) {
-        auto root = fromData(data);
+        auto root = fromData(data, /*checkSharedKeyExists=*/ false);
         if (!root)
             return false;
         // Walk the tree and collect every value with its address:

--- a/Fleece/Core/Value.hh
+++ b/Fleece/Core/Value.hh
@@ -65,7 +65,7 @@ namespace fleece { namespace impl {
             Validates the data first; if it's invalid, returns nullptr.
             Does NOT copy or take ownership of the data; the caller is responsible for keeping it
             intact. Any changes to the data will invalidate any FLValues obtained from it. */
-        static const Value* fromData(slice) noexcept;
+        static const Value* fromData(slice, bool checkSharedKeyExists= true) noexcept;
 
         /** Returns a pointer to the root value in the encoded data, without validating.
             This is a lot faster, but "undefined behavior" occurs if the data is corrupt... */
@@ -206,7 +206,10 @@ namespace fleece { namespace impl {
         { }
 
         static const Value* findRoot(slice) noexcept FLPURE;
-        bool validate(const void* dataStart, const void *dataEnd) const noexcept FLPURE;
+        bool validate(const void* dataStart, const void *dataEnd,
+                      bool checkSharedKeyExists) const noexcept FLPURE;
+        bool isValidKey(SharedKeys* sharedKeys, bool checkSharedKeyExists, const Value** lastKey,
+                        bool wide) const noexcept FLPURE;
 
         internal::tags tag() const noexcept FLPURE   {return (internal::tags)(_byte[0] >> 4);}
         unsigned tinyValue() const noexcept FLPURE   {return _byte[0] & 0x0F;}
@@ -239,6 +242,7 @@ namespace fleece { namespace impl {
         FLPURE const Value* next() const noexcept         {return next(WIDE);}
 
         size_t dataSize() const noexcept FLPURE;
+        ptrdiff_t carefulDataSize(const void* dataEnd) const noexcept FLPURE;
 
         //////// Here's the data:
 

--- a/Fleece/Mutable/HeapDict.cc
+++ b/Fleece/Mutable/HeapDict.cc
@@ -115,7 +115,7 @@ namespace fleece { namespace impl { namespace internal {
             key = encodeKey(stringKey);
             slotp = &_makeValueFor(key);
         }
-        if (slotp->empty() && !(_source && _source->get(key)))
+        if (slotp->empty() && !(_source && _source->get(key, /*returnUndefined =*/ true)))
             ++_count;
         markChanged();
         return *slotp;
@@ -177,7 +177,7 @@ namespace fleece { namespace impl { namespace internal {
 
     void HeapDict::remove(slice stringKey) {
         key_t key = encodeKey(stringKey);
-        if (_source && _source->get(key)) {
+        if (_source && _source->get(key, /*returnUndefined =*/ true)) {
             auto it = _map.find(key);
             if (it != _map.end()) {
                 if (_usuallyFalse(!it->second))

--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -257,6 +257,13 @@ namespace fleece { namespace impl {
                 case kStringTag:
                     set(value->asString());
                     break;
+                case kBinaryTag:
+                    setData(value->asData());
+                    break;
+                case kIntTag:
+                    if (value->isUnsigned()) set(value->asUnsigned());
+                    else set(value->asInt());
+                    break;
                 case kFloatTag:
                     set(value->asDouble());
                     break;

--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -16,6 +16,7 @@
 #include "Encoder.hh"
 #include "varint.hh"
 #include <algorithm>
+#include <cmath>
 
 namespace fleece { namespace impl {
     using namespace std;
@@ -176,7 +177,7 @@ namespace fleece { namespace impl {
         } else {
             setPointer(HeapValue::create(d)->asValue());
         }
-        assert_postcondition(asValue()->asDouble() == d);
+        assert_postcondition(asValue()->asDouble() == d || (isnan(asValue()->asDouble()) && isnan(d)));
     }
 
 

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -366,3 +366,17 @@ TEST_CASE("API MutableDict item bool conversion", "[API]") {
     }
     CHECK(dict.toJSONString() == "{\"a_key\":6}");
 }
+
+
+TEST_CASE("API Mutable copy of Dict with undefined value", "[API]") {
+    auto enc = fleece::Encoder();
+    enc.beginDict();
+    enc.writeKey("a");
+    enc.writeUndefined();
+    enc.endDict();
+    auto data = enc.finish();
+    auto doc = Doc(data);
+    auto copy = doc.root().asDict().mutableCopy(kFLCopyImmutables);
+    CHECK(copy.count() == 1);
+    CHECK(copy["a"].type() == kFLUndefined);
+}

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -408,3 +408,16 @@ TEST_CASE("API Mutable copy of Dict with data", "[API]") {
     CHECK(copy["a"].type() == kFLData);
     CHECK(copy["a"].asData() == "aaaaaaaaaaaaaaaa"_sl);
 }
+
+TEST_CASE("API Mutable copy of Dict with empty string shared key", "[API]") {
+    auto sk = fleece::SharedKeys::create();
+    auto enc = fleece::Encoder(sk);
+    enc.beginDict();
+    enc.writeKey("");
+    enc.writeNull();
+    enc.endDict();
+    auto doc = enc.finishDoc();
+    auto copy = doc.root().asDict().mutableCopy(kFLCopyImmutables);
+    CHECK(copy.count() == 1);
+    CHECK(copy[""].type() == kFLNull);
+}

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -380,3 +380,31 @@ TEST_CASE("API Mutable copy of Dict with undefined value", "[API]") {
     CHECK(copy.count() == 1);
     CHECK(copy["a"].type() == kFLUndefined);
 }
+
+TEST_CASE("API Mutable copy of Dict with int", "[API]") {
+    auto enc = fleece::Encoder();
+    enc.beginDict();
+    enc.writeKey("a");
+    enc.writeInt(0xFFFFFFFFFFFFFF);
+    enc.endDict();
+    auto data = enc.finish();
+    auto doc = Doc(data);
+    auto copy = doc.root().asDict().mutableCopy(kFLCopyImmutables);
+    CHECK(copy.count() == 1);
+    CHECK(copy["a"].type() == kFLNumber);
+    CHECK(copy["a"].asInt() == 0xFFFFFFFFFFFFFF);
+}
+
+TEST_CASE("API Mutable copy of Dict with data", "[API]") {
+    auto enc = fleece::Encoder();
+    enc.beginDict();
+    enc.writeKey("a");
+    enc.writeData("aaaaaaaaaaaaaaaa"_sl);
+    enc.endDict();
+    auto data = enc.finish();
+    auto doc = Doc(data);
+    auto copy = doc.root().asDict().mutableCopy(kFLCopyImmutables);
+    CHECK(copy.count() == 1);
+    CHECK(copy["a"].type() == kFLData);
+    CHECK(copy["a"].asData() == "aaaaaaaaaaaaaaaa"_sl);
+}

--- a/Tests/SharedKeysTests.cc
+++ b/Tests/SharedKeysTests.cc
@@ -19,6 +19,7 @@
 
 using namespace std;
 using namespace fleece::impl;
+using namespace fleece::impl::internal;
 
 
 TEST_CASE("basic", "[SharedKeys]") {
@@ -472,9 +473,11 @@ TEST_CASE("big JSON encoding", "[SharedKeys]") {
     int nameKey;
     REQUIRE(sk->encode("name"_sl, nameKey));
 
+    gDisableNecessarySharedKeysCheck = true;
     auto root = Value::fromTrustedData(encoded)->asArray();
     auto person = root->get(33)->asDict();
     const Value *name = person->get(nameKey);
     std::string nameStr = (std::string)name->asString();
     REQUIRE(nameStr == std::string("Janet Ayala"));
+    gDisableNecessarySharedKeysCheck = false;
 }


### PR DESCRIPTION
I've been experimenting with testing Fleece with fuzzed Fleece data. 

In the process, I had to expand the validation of untrusted Fleece data. It seems to be quite complete now. Fuzzing for an extended amount of time does not produce new assert failures or crashes.

I found and fixed the following issues:

- An assert is not handling comparing two `nan` floats.
- `ValueSlot::copyValue` does not handle integers and binary data.
- An `undefined` value in a `Dict` causes an incorrect count in deep mutable copies.
  The problem is that in [this line](https://github.com/couchbase/fleece/blob/master/Fleece/Mutable/HeapDict.cc#L118) `_source->get(key)` returns `nullptr` for a `undefined` value, so `ValueSlot::setting` is not able to distinguish between a new key and a key with an `undefined` value.
  I'm not sure if my fix is the right approach, though.

The fuzzing function I used is relatively simple. With a more advanced function (e.g. also handling shared keys) it might be possible to discover more issues.

```c++
#include <cstdlib>

#include "fleece/Fleece.hh"
#include "fleece/Mutable.hh"
#include "fleece/Expert.hh"

static void IterateValue(fleece::Value& value) {
    fleece::DeepIterator copyIter(value);
    for (; copyIter; ++copyIter) {}
}

extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
    fleece::alloc_slice slice(Data, Size);
    fleece::Doc doc(slice);

    if (doc) {
        auto root = doc.root();
        IterateValue(root);

        switch (root.type()) {
            case kFLArray: {
                auto copy = root.asArray().mutableCopy(kFLDeepCopyImmutables);
                IterateValue(copy);
                break;
            }
            case kFLDict: {
                auto copy = root.asDict().mutableCopy(kFLDeepCopyImmutables);
                IterateValue(copy);
                break;
            }
            default:
                return 0;
        }
    }

    return 0;
}
```

Fuzzing with LLVM's libFuzzer is quite straightforward and could be automated in CI.