### PR TITLE
Handle binary and int values in `ValueSlot::copyValue`

### DIFF
--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -256,6 +256,13 @@ namespace fleece { namespace impl {
                 case kStringTag:
                     set(value->asString());
                     break;
+                case kBinaryTag:
+                    setData(value->asData());
+                    break;
+                case kIntTag:
+                    if (value->isUnsigned()) set(value->asUnsigned());
+                    else set(value->asInt());
+                    break;
                 case kFloatTag:
                     set(value->asDouble());
                     break;

--- a/Tests/API_ValueTests.cc
+++ b/Tests/API_ValueTests.cc
@@ -366,3 +366,32 @@ TEST_CASE("API MutableDict item bool conversion", "[API]") {
     }
     CHECK(dict.toJSONString() == "{\"a_key\":6}");
 }
+
+
+TEST_CASE("API Mutable copy of Dict with int", "[API]") {
+    auto enc = fleece::Encoder();
+    enc.beginDict();
+    enc.writeKey("a");
+    enc.writeInt(0xFFFFFFFFFFFFFF);
+    enc.endDict();
+    auto data = enc.finish();
+    auto doc = Doc(data);
+    auto copy = doc.root().asDict().mutableCopy(kFLCopyImmutables);
+    CHECK(copy.count() == 1);
+    CHECK(copy["a"].type() == kFLNumber);
+    CHECK(copy["a"].asInt() == 0xFFFFFFFFFFFFFF);
+}
+
+TEST_CASE("API Mutable copy of Dict with data", "[API]") {
+    auto enc = fleece::Encoder();
+    enc.beginDict();
+    enc.writeKey("a");
+    enc.writeData("aaaaaaaaaaaaaaaa"_sl);
+    enc.endDict();
+    auto data = enc.finish();
+    auto doc = Doc(data);
+    auto copy = doc.root().asDict().mutableCopy(kFLCopyImmutables);
+    CHECK(copy.count() == 1);
+    CHECK(copy["a"].type() == kFLData);
+    CHECK(copy["a"].asData() == "aaaaaaaaaaaaaaaa"_sl);
+}


### PR DESCRIPTION
With this change all types of values that might not be inlinable into `ValueSlot` are handled in `ValueSlot::copyValue`.

NB: This was discovered through fuzzing (#166).