### PR TITLE
Fix count of dicts with parent

### DIFF
--- a/Fleece/Core/Dict.cc
+++ b/Fleece/Core/Dict.cc
@@ -313,7 +313,7 @@ namespace fleece { namespace impl {
         if (_usuallyFalse(isMutable()))
             return heapDict()->count();
         Array::impl imp(this);
-        if (_usuallyFalse(imp._count > 1 && isMagicParentKey(imp._first))) {
+        if (_usuallyFalse(imp._count >= 1 && isMagicParentKey(imp._first))) {
             // Dict has a parent; this makes counting much more expensive!
             uint32_t c = 0;
             for (iterator i(this); i; ++i)


### PR DESCRIPTION
This change fixes an off-by-one bug in `Dict::count` which affects dicts that only contain the reference to a parent dict.

NB: This was discovered through fuzzing (#166).