### PR TITLE
Fix assert to handle `nan`

### DIFF
--- a/Fleece/Mutable/ValueSlot.cc
+++ b/Fleece/Mutable/ValueSlot.cc
@@ -16,6 +16,7 @@
 #include "Encoder.hh"
 #include "varint.hh"
 #include <algorithm>
+#include <cmath>
 
 namespace fleece { namespace impl {
     using namespace std;
@@ -176,7 +177,7 @@ namespace fleece { namespace impl {
         } else {
             setPointer(HeapValue::create(d)->asValue());
         }
-        assert_postcondition(asValue()->asDouble() == d);
+        assert_postcondition(asValue()->asDouble() == d || (isnan(asValue()->asDouble()) && isnan(d)));
     }
 
 


### PR DESCRIPTION
Fixes the assert in `ValueSlot::set` to handle `nan` values.

NB: This was discovered through fuzzing (#166).