### PR TITLE
Move InstanceCounted::untrack from private to protected section.

### DIFF
--- a/API/fleece/InstanceCounted.hh
+++ b/API/fleece/InstanceCounted.hh
@@ -47,9 +47,9 @@ namespace fleece {
 
     protected:
         InstanceCounted(size_t offset)              {track(offset);}
+        void untrack() const;
     private:
         void track(size_t offset =0) const;
-        void untrack() const;
         static void dumpInstances(function_ref<void(const InstanceCounted*)>*);
 
 #else


### PR DESCRIPTION
It is to fix an error that occurred when updating Xcode from 16.2 to 16.4.