### PR TITLE
Improvements to Ref<>

### DIFF
--- a/Fleece/Core/Builder.cc
+++ b/Fleece/Core/Builder.cc
@@ -48,13 +48,13 @@ namespace fleece::impl::builder {
         RetainedConst<Value> buildValue() {
             switch (peekToken()) {
                 case '[': {
-                    Retained<MutableArray> array = MutableArray::newArray();
+                    Ref<MutableArray> array = MutableArray::newArray();
                     _buildInto(array);
                     finished();
                     return array.get();
                 }
                 case '{': {
-                    Retained<MutableDict> dict = MutableDict::newDict();
+                    Ref<MutableDict> dict = MutableDict::newDict();
                     _buildInto(dict);
                     finished();
                     return dict.get();
@@ -82,13 +82,13 @@ namespace fleece::impl::builder {
         bool _buildValue(ValueSlot &inSlot) {
             switch (peekValue()) {
                 case ValueType::array: {
-                    Retained<MutableArray> array = MutableArray::newArray();
+                    Ref<MutableArray> array = MutableArray::newArray();
                     _buildInto(array);
                     inSlot.set(array);
                     break;
                 }
                 case ValueType::dict: {
-                    Retained<MutableDict> dict = MutableDict::newDict();
+                    Ref<MutableDict> dict = MutableDict::newDict();
                     _buildInto(dict);
                     inSlot.set(dict);
                     break;

--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -350,11 +350,11 @@ namespace fleece { namespace impl {
     }
 
 
-    Retained<Doc> Doc::fromFleece(const alloc_slice &fleece, Trust trust) {
+    Ref<Doc> Doc::fromFleece(const alloc_slice &fleece, Trust trust) {
         return new Doc(fleece, trust);
     }
 
-    Retained<Doc> Doc::fromJSON(slice json, SharedKeys *sk) {
+    Ref<Doc> Doc::fromJSON(slice json, SharedKeys *sk) {
         return new Doc(JSONConverter::convertJSON(json, sk), kTrusted, sk);
     }
 

--- a/Fleece/Core/Doc.hh
+++ b/Fleece/Core/Doc.hh
@@ -109,8 +109,8 @@ namespace fleece { namespace impl {
             slice subData,
             Trust =kUntrusted) noexcept;
 
-        static Retained<Doc> fromFleece(const alloc_slice &fleece, Trust =kUntrusted);
-        static Retained<Doc> fromJSON(slice json, SharedKeys* =nullptr);
+        static Ref<Doc> fromFleece(const alloc_slice &fleece, Trust =kUntrusted);
+        static Ref<Doc> fromJSON(slice json, SharedKeys* =nullptr);
 
         static RetainedConst<Doc> containing(const Value* NONNULL) noexcept;
 

--- a/Fleece/Core/Encoder.cc
+++ b/Fleece/Core/Encoder.cc
@@ -146,12 +146,11 @@ namespace fleece { namespace impl {
         return out;
     }
 
-    Retained<Doc> Encoder::finishDoc() {
-        Retained<Doc> doc = new Doc(finish(),
-                                    Doc::kTrusted,
-                                    _sharedKeys,
-                                    (_markExternPtrs ? _base : slice()));
-        return doc;
+    Ref<Doc> Encoder::finishDoc() {
+        return new Doc(finish(),
+                          Doc::kTrusted,
+                          _sharedKeys,
+                          (_markExternPtrs ? _base : slice()));
     }
 
     // Returns position in the stream of the next write. Pads stream to even pos if necessary.

--- a/Fleece/Core/Encoder.hh
+++ b/Fleece/Core/Encoder.hh
@@ -67,7 +67,7 @@ namespace fleece { namespace impl {
         alloc_slice finish();
 
         /** Returns the encoded data as a Doc. This implicitly calls end(). */
-        Retained<Doc> finishDoc();
+        Ref<Doc> finishDoc();
 
         /** Resets the encoder so it can be used again. */
         void reset();

--- a/Fleece/Mutable/MutableArray.hh
+++ b/Fleece/Mutable/MutableArray.hh
@@ -24,20 +24,20 @@ namespace fleece { namespace impl {
     public:
 
         /** Creates a new array of size `initialCount` filled with null Values. */
-        static Retained<MutableArray> newArray(uint32_t initialCount =0) {
+        static Ref<MutableArray> newArray(uint32_t initialCount =0) {
             return (new internal::HeapArray(initialCount))->asMutableArray();
         }
 
         /** Creates a copy of `a`, or an empty array if `a` is null.
             If `deepCopy` is true, nested mutable collections will be recursively copied too. */
-        static Retained<MutableArray> newArray(const Array *a, CopyFlags flags =kDefaultCopy) {
+        static Ref<MutableArray> newArray(const Array *a, CopyFlags flags =kDefaultCopy) {
             auto ha = retained(new internal::HeapArray(a));
             if (flags)
                 ha->copyChildren(flags);
             return ha->asMutableArray();
         }
 
-        Retained<MutableArray> copy(CopyFlags f = kDefaultCopy)    {return newArray(this, f);}
+        Ref<MutableArray> copy(CopyFlags f = kDefaultCopy)    {return newArray(this, f);}
 
         const Array* source() const                 {return heapArray()->_source;}
         bool isChanged() const                      {return heapArray()->isChanged();}

--- a/Fleece/Mutable/MutableDict.hh
+++ b/Fleece/Mutable/MutableDict.hh
@@ -21,11 +21,11 @@ namespace fleece { namespace impl {
     class MutableDict : public Dict {
     public:
 
-        static Retained<MutableDict> newDict(const Dict *d =nullptr, CopyFlags flags =kDefaultCopy) {
+        static Ref<MutableDict> newDict(const Dict *d =nullptr, CopyFlags flags =kDefaultCopy) {
             return retained(new internal::HeapDict(d, flags))->asMutableDict();
         }
 
-        Retained<MutableDict> copy(CopyFlags f =kDefaultCopy) {return newDict(this, f);}
+        Ref<MutableDict> copy(CopyFlags f =kDefaultCopy) {return newDict(this, f);}
 
         const Dict* source() const                          {return heapDict()->_source;}
         bool isChanged() const                              {return heapDict()->isChanged();}

--- a/Fleece/Mutable/ValueSlot.hh
+++ b/Fleece/Mutable/ValueSlot.hh
@@ -57,9 +57,8 @@ namespace fleece { namespace impl {
 
         // These methods allow set(Value*) to be called, without allowing any other pointer type
         // to be used; without them, set(Foo*) would incorrectly call set(bool).
-        template <class T> void set(const T* t)                 {setValue(t);}
-        template <class T> void set(const Retained<T> &t)       {setValue(t);}
-        template <class T> void set(const RetainedConst<T> &t)  {setValue(t);}
+        template <class T> void set(const T* t)                             {setValue(t);}
+        template <class T, Nullability N> void set(const Retained<T,N> &t)  {setValue(t);}
 
         /** Replaces an external value with a copy of itself. */
         void copyValue(CopyFlags);

--- a/Tests/EncoderTests.cc
+++ b/Tests/EncoderTests.cc
@@ -721,7 +721,9 @@ public:
 
 #if FL_HAVE_TEST_FILES
     TEST_CASE_METHOD(EncoderTests, "Encode To File", "[Encoder]") {
-    	auto doc = readTestFile("1000people.fleece");
+        if (!sCreated1000PeopleFile)
+            create100PeopleFleeceFile();
+        auto doc = readTestFile("1000people.fleece");
         auto root = Value::fromTrustedData(doc)->asArray();
 
         {


### PR DESCRIPTION
- `destroy()` method releases the reference, equivalent to `= nullptr`
  which is otherwise disallowed. This is for cases where a non-null
  reference needs to be released in e.g. a `close()` method, but it's
  understood that it can't be accessed again. This allows it to be
  typed as `Ref<>`.
- `isValid()` returns false if the Ref has been destroyed.
- `operator bool` is disallowed for Ref<>, because it's conceptually
  not nullable, so testing it is usually a sign that you're doing
  unnecessary checks. If you really need to check, use isValid().

Also converted some `Retained`s into `Ref`s in the Fleece codebase, and fixed a template method in ValueSlot that didn't work with `Ref`.

Also fixed some new clang printf warnings.