### PR TITLE
Weak references

### DIFF
--- a/API/fleece/WeakRef.hh
+++ b/API/fleece/WeakRef.hh
@@ -1,0 +1,214 @@
+//
+// WeakRef.hh
+//
+// Copyright 2026-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+//
+
+#pragma once
+#include "RefCounted.hh"
+
+FL_ASSUME_NONNULL_BEGIN
+
+namespace fleece {
+
+    [[noreturn]] void _failZombie(void*);
+
+
+    /** A smart pointer very much like \ref Retained except that it holds a _weak_ reference.
+     *  The existence of the weak reference does not keep the referred-to object alive on its own;
+     *  once no strong references exist, the object is freed and any weak references cleared.
+     *
+     *  `WeakRetained` is useful for breaking reference cycles that could otherwise cause leaks.
+     *  If one object in the cycle uses a WeakRef instead of a Ref, both objects will be freed
+     *  properly once there are no external references to them.
+     *
+     *  You can't dereference a WeakRef to a plain pointer, because that pointer could be
+     *  invalidated at any moment by another thread releasing the last strong reference.
+     *  Instead, dereferencing returns a Retained<> instance with a safe strong reference.
+     *
+     *  It's important to remember that a WeakRef can be cleared unexpectedly. Unless you know
+     *  for a fact that the pointee is still alive, it's recommended to call \ref tryGet and
+     *  test the return value before using it, or else call \ref use.
+     */
+    template <class T, Nullability N = MaybeNull>
+    class WeakRetained {
+    public:
+        using T_ptr = typename nullable_if<T,N>::ptr; // This is `T*` with appropriate nullability
+
+        WeakRetained() noexcept requires (N==MaybeNull)               :_ref(nullptr) { }
+        WeakRetained(std::nullptr_t) noexcept requires (N==MaybeNull) :WeakRetained() { } // optimization
+
+        #if __has_feature(nullability)
+        WeakRetained(T* FL_NONNULL t) noexcept                          :_ref(_weakRetain(t)) { }
+        WeakRetained(T* FL_NULLABLE t) noexcept requires(N==MaybeNull)  :_ref(_weakRetain(t)) { }
+        #else
+        WeakRetained(T* t) noexcept                                 :_ref(_weakRetain(t)) { }
+        #endif
+
+        WeakRetained(const WeakRetained &r) noexcept                :_ref(_weakRetain(r._ref)) { }
+        WeakRetained(WeakRetained &&r) noexcept                     :_ref(std::move(r).detach()) { }
+
+        template <typename U, Nullability UN> requires (std::derived_from<U,T> && N >= UN)
+        WeakRetained(const WeakRetained<U,UN> &r) noexcept          :_ref(_weakRetain(r._ref)) { }
+        template <typename U, Nullability UN> requires (std::derived_from<U,T> && N >= UN)
+        WeakRetained(WeakRetained<U,UN> &&r) noexcept               :_ref(std::move(r).detach()) { }
+
+        ~WeakRetained() noexcept                                    {if (_ref) _ref->_weakRelease();}
+
+        WeakRetained& operator=(T_ptr t) & noexcept {
+            _weakRetain(t);
+            std::swap(_ref, t);
+            if (t) t->_weakRelease();
+            return *this;
+        }
+
+        WeakRetained& operator=(std::nullptr_t) & noexcept requires(N==MaybeNull) { // optimized assignment
+            auto oldRef = _ref;
+            _ref = nullptr;
+            if (oldRef) oldRef->_weakRelease();
+            return *this;
+        }
+
+        WeakRetained& operator=(const WeakRetained &r) & noexcept       {*this = r._ref; return *this;}
+
+        template <typename U, Nullability UN> requires(std::derived_from<U,T> && N >= UN)
+        WeakRetained& operator=(const WeakRetained<U,UN> &r) & noexcept {*this = r._ref; return *this;}
+
+        WeakRetained& operator= (WeakRetained &&r) & noexcept {
+            std::swap(_ref, r._ref);   // old _ref will be released by r's destructor
+            return *this;
+        }
+
+        template <typename U, Nullability UN> requires(std::derived_from<U,T> && N >= UN)
+        WeakRetained& operator= (WeakRetained<U,UN> &&r) & noexcept {
+            if ((void*)&r != this) {
+                auto oldRef = _ref;
+                _ref = std::move(r).detach();
+                _weakRelease(oldRef);
+            }
+            return *this;
+        }
+
+        /// Converts any WeakRetained to non-nullable form (WeakRef), or throws if its value is nullptr.
+        WeakRetained<T,NonNull> asWeakRef() const & noexcept(!N) {return WeakRetained<T,NonNull>(_ref);}
+
+        WeakRetained<T,NonNull> asWeakRef() && noexcept(!N) {
+            WeakRetained<T,NonNull> result(_ref, false);
+            _ref = nullptr;
+            return result;
+        }
+
+        /// Returns true if I hold a non-null pointer.
+        /// Does _not_ check if the pointed-to object still exists.
+        /// @warning  Do not use this to preflight \ref asRetained.
+        explicit operator bool () const noexcept FLPURE {return N==NonNull || (_ref != nullptr);}
+
+        /// True if the object no longer exists.
+        bool invalidated() const noexcept               {return !_ref || _ref->refCount() == 0;}
+
+        /// If this holds a non-null pointer, and the object pointed to still exists,
+        /// returns a `Retained` instance holding a new strong reference to it.
+        /// Otherwise returns an empty (nullptr) `Retained`.
+        /// @warning You **must** check the `Retained` for null before dereferencing it!
+        Retained<T> tryGet() const noexcept {
+            if (_ref->_weakToStrong())
+                return Retained<T>::adopt(_ref);
+            else
+                return nullptr;
+        }
+
+        /// If this holds a non-null pointer, and the object pointed to still exists,
+        /// returns a `Retained` instance holding a new strong reference to it; otherwise throws.
+        /// @throws std::illegal_state if the object no longer exists.
+        Retained<T,N> get() const {
+            if (!_ref || _ref->_weakToStrong())
+                return Retained<T,N>::adopt(_ref);
+            else [[unlikely]]
+                _failZombie(_ref);
+        }
+
+        /// Similar to \ref get, will throw if the pointed-to object has been deleted.
+        /// @throws std::illegal_state if the object no longer exists.
+        Retained<T> operator->() const {return get();}
+
+        /// An alternative to \ref tryGet. If the object pointed to still exists,
+        /// calls the function `fn` with a pointer to it, then returns true.
+        /// Otherwise just returns false.
+        template <std::invocable<T*> FN>
+        [[nodiscard]] bool use(FN&& fn) requires(std::is_void_v<std::invoke_result_t<FN,T*>>) {
+            if (auto ref = tryGet()) {
+                fn(ref.get());
+                return true;
+            } else {
+                return false;
+            }
+        }
+
+        /// An alternative to \ref tryGet. If the object pointed to still exists,
+        /// calls the function `fn` with a pointer to it, returning whatever it returned.
+        /// Otherwise calls `elsefn` with no arguments, returning whatever it returned.
+        template <std::invocable<T*> FN, std::invocable<> ELSEFN>
+        auto use(FN&& fn, ELSEFN&& elsefn) {
+            if (auto ref = tryGet()) {
+                return fn(ref.get());
+            } else {
+                return elsefn();
+            }
+        }
+
+    private:
+        template <class U, Nullability UN> friend class WeakRetained;
+
+        WeakRetained(T_ptr t, bool) noexcept(N==MaybeNull) // private no-retain ctor
+        :_ref(t) {
+            if constexpr (N == NonNull) {
+                if (t == nullptr) [[unlikely]]
+                    _failNullRef();
+            }
+        }
+
+        static T_ptr _weakRetain(T_ptr t) noexcept {
+            if constexpr (N == NonNull) {
+                t->_weakRetain(); // this is faster, and it detects illegal null (by signal)
+            } else {
+                if (t) t->_weakRetain();
+            }
+            return t;
+        }
+
+        static void _weakRelease(T_ptr t) noexcept {
+            if constexpr (N == NonNull) {
+                t->_weakRelease(); // this is faster, and it detects illegal null (by signal)
+            } else {
+                if (t) t->_weakRelease();
+            }
+        }
+
+        [[nodiscard]] T_ptr detach() && noexcept        {return std::exchange(_ref, nullptr);}
+
+        // _ref has to be declared nullable, even when N==NonNull, because a move assignment
+        // sets the moved-from _ref to nullptr. The WeakRetained may not used any more in this state,
+        // but it will be destructed, which is why the destructor also checks for nullptr.
+        T* FL_NULLABLE _ref;
+    };
+
+    template <class T> WeakRetained(T* FL_NULLABLE) -> WeakRetained<T>; // deduction guide
+
+    /// WeakRef<T> is an alias for a non-nullable WeakRetained<T>.
+    template <class T> using WeakRef = WeakRetained<T, NonNull>;
+
+    /// NullableWeakRef<T> is an alias for a (default) nullable WeakRetained<T>.
+    template <class T> using NullableWeakRef = WeakRetained<T, MaybeNull>;
+
+    /// WeakRetainedConst is an alias for a WeakRetained that holds a const pointer.
+    template <class T> using WeakRetainedConst = WeakRetained<const T>;
+
+}
+
+FL_ASSUME_NONNULL_END

--- a/Fleece/Support/RefCounted.cc
+++ b/Fleece/Support/RefCounted.cc
@@ -11,6 +11,7 @@
 //
 
 #include "fleece/RefCounted.hh"
+#include "fleece/WeakRef.hh"
 #include "Backtrace.hh"
 #include <stdexcept>
 #include <stdio.h>
@@ -22,12 +23,141 @@
 
 namespace fleece {
 
-#if !DEBUG
-    __hot void RefCounted::_release() const noexcept {
-        if (--_refCount <= 0)
-            delete this;
+    static std::atomic<size_t> sZombieCount = 0;
+
+    static void fail(const RefCounted *obj, const char *what, uint64_t refCount, bool andThrow =true);
+
+
+    static uint32_t refCountOf(uint64_t rc) {
+        return uint32_t(rc);
+    }
+    static uint32_t weakCountOf(uint64_t rc) {
+        return uint32_t(rc >> 32);
+    }
+    #if DEBUG
+    static bool invalidCount(uint32_t count) {
+        return count >= 0x80000000;
+    }
+    #endif
+
+
+    int RefCounted::refCount() const {
+        return std::max(refCountOf(_bothRefCounts), 1u) - 1;  // Don't expose the internal 1 extra ref
+    }
+
+
+    std::pair<int, int> RefCounted::refCounts() const {
+        uint64_t both = _bothRefCounts;
+        return {std::max(refCountOf(both), 1u) - 1, weakCountOf(both)};
+    }
+
+
+    size_t RefCounted::zombieCount() {
+        return sZombieCount;
+    }
+
+
+    // In debug builds, sanity-check the ref-count on retain and release. This can detect several
+    // problems, like a corrupted object (garbage out-of-range refcount), or a race condition where
+    // one thread releases the last reference to an object and destructs it, while simultaneously
+    // another thread (that shouldn't have a reference but does due to a bug) retains or releases
+    // the object.
+
+
+    #if DEBUG
+    void RefCounted::_retain() const noexcept {
+        auto oldRef = _bothRefCounts++;
+
+        // Special case: the initial retain of a new object that takes it to refCount 1
+        if (oldRef == kInitialRefCount) {
+            _bothRefCounts = 2;
+            return;
+        }
+
+        // Otherwise, if the refCount was 0 we have a bug where another thread is destructing
+        // the object, so this thread shouldn't have a reference at all.
+        // Or if the refcount was negative or ridiculously big, this is probably a garbage object.
+        if (refCountOf(oldRef) <= 1 || refCountOf(oldRef) >= 0x7FFFFFFF)
+            fail(this, "retained", oldRef);
     }
 #endif
+
+
+    __hot void RefCounted::_release() const noexcept {
+        auto newRef = --_bothRefCounts;
+        if (refCountOf(newRef) == 1) {
+            if (weakCountOf(newRef) == 0) {
+                delete this;
+            } else {
+                this->~RefCounted();        // Weak references remain, so don't delete yet
+                ++sZombieCount;
+                if (--_bothRefCounts == 0) {
+                    operator delete(const_cast<RefCounted*>(this));
+                    --sZombieCount;
+                }
+            }
+        }
+#if DEBUG
+        else if (refCountOf(newRef) == 0 || invalidCount(refCountOf(newRef)))
+            fail(this, "released", newRef + 1);
+#endif
+    }
+
+
+    void RefCounted::_weakRetain() const noexcept {
+        auto newRef = _bothRefCounts += (1ull << 32);
+#if DEBUG
+        if (weakCountOf(newRef) < 1 || invalidCount(weakCountOf(newRef)))
+            fail(this, "weakRetained", newRef - (1ull << 32));
+#endif
+    }
+
+
+    void RefCounted::_weakRelease() const noexcept {
+        auto newRef = _bothRefCounts -= (1ull << 32);
+        if (weakCountOf(newRef) == 0) {
+            if (refCountOf(newRef) == 0) {
+                operator delete(const_cast<RefCounted*>(this));
+                --sZombieCount;
+            }
+        }
+#if DEBUG
+        else if (invalidCount(weakCountOf(newRef)))
+            fail(this, "weakReleased", newRef + (1ull << 32));
+#endif
+    }
+
+
+    bool RefCounted::_weakToStrong() const noexcept {
+        auto refs = _bothRefCounts.load();
+        do {
+            #if DEBUG
+            if (weakCountOf(refs) == 0 || invalidCount(weakCountOf(refs)) || invalidCount(refCountOf(refs)))
+                fail(this, "weakToStrong", refs);
+            #endif
+            if (refCountOf(refs) <= 1)
+                return false;   // No strong refs; fail
+        } while (!_bothRefCounts.compare_exchange_strong(refs, refs + 1));
+        // Successfully added a strong ref; successs
+        return true;
+    }
+
+
+    RefCounted::~RefCounted() noexcept {
+        if (auto refs = _bothRefCounts.load(); refCountOf(refs) != 1) {
+#if DEBUG
+            if (refCountOf(refs) != kInitialRefCount)
+#endif
+            {
+                // Detect if the destructor is not called from _release, i.e. the object still has
+                // references. This is probably a direct call to delete, which is illegal.
+                // Or possibly some other thread had a pointer to this object without a proper
+                // reference, and then called retain() on it after this thread's release() set the
+                // ref-count to 0.
+                fail(this, "destructed", refs, false);
+            }
+        }
+    }
 
 
     __hot void release(const RefCounted *r) noexcept {
@@ -45,20 +175,28 @@ namespace fleece {
     }
 
 
-    __cold static void fail(const RefCounted *obj, const char *what, int refCount,
-                            bool andThrow =true)
-    {
+    // Called by Retained<>. Broken out so it's not duplicated in each instantiaton of the template.
+    __cold void _failNullRef() {
+        throw std::invalid_argument("storing nullptr in a non-nullable Retained");
+    }
+
+    __cold void _failZombie(void* zombie) {
+        throw std::invalid_argument("storing nullptr in a non-nullable Retained");
+    }
+
+
+    __cold static void fail(const RefCounted *obj, const char *what, uint64_t refCount, bool andThrow) {
         char *message = nullptr;
         int n = asprintf(&message,
-                 "RefCounted object <%s @ %p> %s while it had an invalid refCount of %d (0x%x)",
-                 Unmangle(typeid(*obj)).c_str(), obj, what, refCount, unsigned(refCount));
+                 "RefCounted object <%s @ %p> %s while it had an invalid refCount of 0x%llx",
+                 Unmangle(typeid(*obj)).c_str(), obj, what, (unsigned long long)refCount);
         if (n < 0)
             throw std::runtime_error("RefCounted object has an invalid refCount");
-#ifdef WarnError
+        #ifdef WarnError
         WarnError("%s", message);
-#else
+        #else
         fprintf(stderr, "WARNING: %s\n", message);
-#endif
+        #endif
         if (andThrow) {
             std::string str(message);
             free(message);
@@ -66,70 +204,6 @@ namespace fleece {
         }
         free(message);
     }
-
-
-    RefCounted::~RefCounted() noexcept {
-        // Store a garbage value to detect use-after-free
-        int32_t oldRef = _refCount.exchange(-9999999);
-        if (_usuallyFalse(oldRef != 0)) {
-#if DEBUG
-            if (oldRef != kCarefulInitialRefCount)
-#endif
-            {
-                // Detect if the destructor is not called from _release, i.e. the object still has
-                // references. This is probably a direct call to delete, which is illegal.
-                // Or possibly some other thread had a pointer to this object without a proper
-                // reference, and then called retain() on it after this thread's release() set the
-                // ref-count to 0.
-                fail(this, "destructed", oldRef, false);
-            }
-        }
-    }
-
-
-    // In debug builds, sanity-check the ref-count on retain and release. This can detect several
-    // problems, like a corrupted object (garbage out-of-range refcount), or a race condition where
-    // one thread releases the last reference to an object and destructs it, while simultaneously
-    // another thread (that shouldn't have a reference but does due to a bug) retains or releases
-    // the object.
-
-
-    void RefCounted::_careful_retain() const noexcept {
-        auto oldRef = _refCount++;
-
-        // Special case: the initial retain of a new object that takes it to refCount 1
-        if (oldRef == kCarefulInitialRefCount) {
-            _refCount = 1;
-            return;
-        }
-
-        // Otherwise, if the refCount was 0 we have a bug where another thread is destructing
-        // the object, so this thread shouldn't have a reference at all.
-        // Or if the refcount was negative or ridiculously big, this is probably a garbage object.
-        if (oldRef <= 0 || oldRef >= 10000000)
-            fail(this, "retained", oldRef);
-    }
-
-
-    void RefCounted::_careful_release() const noexcept {
-        auto oldRef = _refCount--;
-
-        // If the refCount was 0 we have a bug where another thread is destructing
-        // the object, so this thread shouldn't have a reference at all.
-        // Or if the refcount was negative or ridiculously big, this is probably a garbage object.
-        if (oldRef <= 0 || oldRef >= 10000000)
-            fail(this, "released", oldRef);
-
-        // If the refCount just went to 0, delete the object:
-        if (oldRef == 1) delete this;
-    }
-
-
-    // Called by Retained<>. Broken out so it's not duplicated in each instantiaton of the template.
-    __cold void _failNullRef() {
-        throw std::invalid_argument("storing nullptr in a non-nullable Retained");
-    }
-
 
 
 }

--- a/Tests/PerfTests.cc
+++ b/Tests/PerfTests.cc
@@ -59,8 +59,8 @@ TEST_CASE("GetUVarint performance", "[.Perf]") {
         }
         bench.stop();
         CHECK(result != 1); // bogus
-        fprintf(stderr, "n = %16llx; %2zd bytes; time = %.3f ns\n",
-                (long long)n, nBytes,
+        fprintf(stderr, "n = %16llx; %2zu bytes; time = %.3f ns\n",
+                (unsigned long long)n, nBytes,
                 bench.elapsed() / kNRounds * 1.0e9);
          d *= 1.5;
     }

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -234,7 +234,7 @@ TEST_CASE("ConcurrentMap concurrency", "[ConcurrentMap]") {
     constexpr size_t bufSize = 10;
     for (int i = 0; i < kSize; i++) {
         char keybuf[bufSize];
-        snprintf(keybuf, bufSize, "%x", i);
+        snprintf(keybuf, bufSize, "%x", unsigned(i));
         keys.push_back(keybuf);
     }
 

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -12,6 +12,7 @@
 
 #include "fleece/FLBase.h"
 #include "fleece/InstanceCounted.hh"
+#include "fleece/WeakRef.hh"
 #include "FleeceTests.hh"
 #include "FleeceImpl.hh"
 #include "Backtrace.hh"
@@ -399,4 +400,77 @@ TEST_CASE("InstanceCounted") {
         CHECK(InstanceCounted::liveInstanceCount() == n + 2);
     }
     CHECK(InstanceCounted::liveInstanceCount() == n);
+}
+
+
+TEST_CASE("WeakRef") {
+    auto n = InstanceCounted::liveInstanceCount();
+    {
+        Retained<ICTest> i1 = make_retained<ICTest>();
+        WeakRetained<ICTest> weak1{i1};
+        {
+            Retained<ICTest> r1 = weak1.tryGet();
+            CHECK(r1 == i1);
+        }
+
+        bool called = false;
+        bool result = weak1.use([&](ICTest* test) {CHECK(test == i1); called = true;});
+        CHECK(result);
+        CHECK(called);
+
+        unsigned v = weak1.use(
+            [&](ICTest* test) {CHECK(test == i1); return 0x1337;},
+            [&]() {return 0xdead;});
+        CHECK(v == 0x1337);
+
+        CHECK(RefCounted::zombieCount() == 0);
+
+        // Release the strong ref:
+        i1 = nullptr;
+
+        CHECK(RefCounted::zombieCount() == 1);
+
+        {
+            Retained<ICTest> r1 = weak1.tryGet();
+            CHECK(r1 == nullptr);
+        }
+
+        called = false;
+        result = weak1.use([&](ICTest* test) {CHECK(test == i1); called = true;});
+        CHECK_FALSE(result);
+        CHECK_FALSE(called);
+
+        v = weak1.use(
+            [&](ICTest* test) {CHECK(test == i1); return 0x1337;},
+            [&]() {return 0xdead;});
+        CHECK(v == 0xdead);
+
+    }
+    CHECK(InstanceCounted::liveInstanceCount() == n);
+    CHECK(RefCounted::zombieCount() == 0);
+}
+
+
+class CycleTest : public ICTest {
+public:
+    Retained<CycleTest> strongRef;
+    WeakRetained<CycleTest> weakRef;
+};
+
+
+TEST_CASE("WeakRef Cycle") {
+    auto n = InstanceCounted::liveInstanceCount();
+
+    Retained<CycleTest> master = make_retained<CycleTest>();
+    Retained<CycleTest> servant = make_retained<CycleTest>();
+    master->strongRef = servant;
+    servant->weakRef = master;
+
+    master = nullptr;
+    CHECK(RefCounted::zombieCount() == 1);
+    CHECK(servant->weakRef.invalidated());
+    servant = nullptr;
+
+    CHECK(InstanceCounted::liveInstanceCount() == n);
+    CHECK(RefCounted::zombieCount() == 0);
 }


### PR DESCRIPTION
Implemented `WeakRetained<>` / `WeakRef<>`.
See the [proposal document](https://github.com/couchbase/fleece/wiki/Weak-References-Proposal) in the wiki.
Lockless algorithms are tricky, so I've detailed exactly how this works.

Also implemented `RetainedBySubclass` and `WeakRetainedBySubclass`, which are a bit tricky to explain; see their doc-comments. The latter is basically a clean replacement for LiteCore's `WeakHolder`.