### PR TITLE
Deal with new warnings in Clang 21 / Xcode 26.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ if(FLEECE_WARNINGS_HARDCORE)
             -Wno-sign-compare # TODO "comparison of integers of different signs"
             -Wno-undefined-func-template # TODO: Can't figure out how to fix MValue.hh
             -Wno-alloca
+            -Wno-allocator-wrappers # "function might be an allocator wrapper"
             -Wno-atomic-implicit-seq-cst # "implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary"
             -Wno-c++98-compat
             -Wno-c++98-compat-pedantic
@@ -63,9 +64,11 @@ if(FLEECE_WARNINGS_HARDCORE)
             -Wno-global-constructors
             -Wno-gnu-anonymous-struct # "anonymous structs are a GNU extension"
             -Wno-gnu-zero-variadic-macro-arguments # "token pasting of ',' and __VA_ARGS__ is a GNU extension"
+            -Wno-implicit-int-float-conversion # "implicit conversion from ... to 'float' may lose precision"
             -Wno-missing-designated-field-initializers # "missing field 'x' initializer"
             -Wno-missing-field-initializers # "missing field 'x' initializer"
             -Wno-nested-anon-types # "anonymous types declared in an anonymous union are an extension"
+            -Wno-nrvo # "not eliding copy on return" -- useful but common, and Catch triggers it
             -Wno-nullability-extension
             -Wno-objc-messaging-id
             -Wno-old-style-cast
@@ -77,6 +80,7 @@ if(FLEECE_WARNINGS_HARDCORE)
             -Wno-super-class-method-mismatch # Obj-C "method parameter type does not match super class method parameter type"
             -Wno-switch-default # "'switch' missing 'default' label"
             -Wno-switch-enum
+            -Wno-thread-safety-negative # "acquiring mutex '_mutex' requires negative capability '!_mutex'"
             -Wno-undef      # `#if X` where X isn't defined
             -Wno-unknown-warning-option # So older Clang doesn't barf on newer warnings listed here :(
             -Wno-unused-macros

--- a/Fleece.xcodeproj/project.pbxproj
+++ b/Fleece.xcodeproj/project.pbxproj
@@ -194,6 +194,8 @@
 		27E3DD4C1DB6C32400F2872D /* CaseListReporter.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27E3DD4A1DB6C32400F2872D /* CaseListReporter.hh */; };
 		27E3DD4D1DB6C32400F2872D /* CatchHelper.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27E3DD4B1DB6C32400F2872D /* CatchHelper.hh */; };
 		27E3DD531DB7DB1C00F2872D /* SharedKeysTests.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27E3DD521DB7DB1C00F2872D /* SharedKeysTests.cc */; };
+		27EBACF42F76015D00A62315 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27C4CEAC2127741000470DE9 /* CoreFoundation.framework */; };
+		27EBACF52F76017500A62315 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27C4CEAE2127743200470DE9 /* Foundation.framework */; };
 		27F25A8420A6560A00E181FA /* LibC++Debug.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27F25A8320A6560900E181FA /* LibC++Debug.cc */; };
 		27F25A8E20AA053D00E181FA /* Pointer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27F25A8C20AA053D00E181FA /* Pointer.cc */; };
 		27F25A8F20AA053D00E181FA /* Pointer.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27F25A8D20AA053D00E181FA /* Pointer.hh */; };
@@ -517,6 +519,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				27EBACF52F76017500A62315 /* Foundation.framework in Frameworks */,
+				27EBACF42F76015D00A62315 /* CoreFoundation.framework in Frameworks */,
 				279AC5381C096B5C002C80DB /* libfleeceStatic.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Fleece/API_Impl/Fleece.cc
+++ b/Fleece/API_Impl/Fleece.cc
@@ -670,7 +670,7 @@ FLDoc FLDoc_FromResultData(FLSliceResult data, FLTrust trust, FLSharedKeys FL_NU
 FLDoc FL_NULLABLE FLDoc_FromJSON(FLSlice json, FLError* FL_NULLABLE outError) FLAPI {
     try {
         return retain(Doc::fromJSON(json));
-    } catchError(outError);
+    } catchError(outError)
     return nullptr;
 }
 
@@ -721,7 +721,7 @@ bool FLEncodeJSONDelta(FLValue FL_NULLABLE old, FLValue FL_NULLABLE nuu, FLEncod
 FLSliceResult FLApplyJSONDelta(FLValue FL_NULLABLE old, FLSlice jsonDelta, FLError * FL_NULLABLE outError) FLAPI {
     try {
         return FLSliceResult(JSONDelta::apply(old, jsonDelta));
-    } catchError(outError);
+    } catchError(outError)
     return {};
 }
 

--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -111,7 +111,7 @@ namespace fleece { namespace impl {
             return;
 
 #if DEBUG
-        if (_data.size < 1e6)
+        if (_data.size < 1'000'000)
             _dataHash = _data.hash();
 #endif
         lock_guard<mutex> lock(sMutex);
@@ -190,7 +190,7 @@ namespace fleece { namespace impl {
         if (!_unregistered.test_and_set()) {            // this is atomic
 #if DEBUG
             // Assert that the data hasn't been changed since I was created:
-            if (_data.size < 1e6 && _data.hash() != _dataHash)
+            if (_data.size < 1'000'000 && _data.hash() != _dataHash)
                 FleeceException::_throw(InternalError,
                     "Memory range (%p .. %p) was altered while Scope %p (sk=%p) was active. "
                     "This usually means the Scope's data was freed/invalidated before the Scope "

--- a/Fleece/Core/Value.cc
+++ b/Fleece/Core/Value.cc
@@ -348,7 +348,7 @@ namespace fleece { namespace impl {
             // If the root is a direct value there better not be any data before it:
             if (_usuallyFalse(s.size != kNarrow))
                 return nullptr;
-        };
+        }
         return root;
     }
 

--- a/Fleece/Support/ConcurrentMap.cc
+++ b/Fleece/Support/ConcurrentMap.cc
@@ -84,7 +84,7 @@ namespace fleece {
     ConcurrentMap::ConcurrentMap(int capacity, int stringCapacity) {
         precondition(capacity <= kMaxCapacity);
         int size;
-        for (size = kMinInitialSize; size * kMaxLoad < capacity; size *= 2)
+        for (size = kMinInitialSize; int(floor(size * kMaxLoad)) < capacity; size *= 2)
             ;
         _capacity = int(floor(size * kMaxLoad));
         _sizeMask = size - 1;

--- a/Fleece/Support/SmallVectorBase.hh
+++ b/Fleece/Support/SmallVectorBase.hh
@@ -164,7 +164,7 @@ namespace fleece {
 
         uint32_t    _size;                      // Current item count
         uint32_t    _capacity :31;              // Current max size before I have to realloc
-        bool        _isBig    : 1;              // True if storage is heap-allocated
+        uint32_t    _isBig    : 1;              // True if storage is heap-allocated [effectively bool]
         union {
             void*   _dataPointer;               // Malloced pointer to data (when _isBig)
             uint8_t _inlineData[kBaseInlineCap];// Data starts here (when !_isBig)

--- a/Fleece/Support/Stopwatch.hh
+++ b/Fleece/Support/Stopwatch.hh
@@ -82,7 +82,7 @@ public:
     }
 
     static double timeScale(double t, const char* &unit) {
-        static const char* kTimeScales[] = {"sec", "ms", "us", "ns"};
+        static constexpr const char* kTimeScales[] = {"sec", "ms", "us", "ns"};
         double scale = 1.0;
         for (unsigned i = 0; i < sizeof(kTimeScales)/sizeof(char*); ++i) {
             unit = kTimeScales[i];

--- a/Fleece/Support/TempArray.hh
+++ b/Fleece/Support/TempArray.hh
@@ -58,6 +58,6 @@
 
     #define TempArray(NAME, TYPE, SIZE) \
         _TempArray<TYPE> NAME(SIZE); \
-        if (!NAME._onHeap && (SIZE) > 0) NAME._array = (TYPE*)alloca((SIZE)*sizeof(TYPE));
+        do { if (!NAME._onHeap && (SIZE) > 0) NAME._array = (TYPE*)alloca((SIZE)*sizeof(TYPE)); } while(false)
 
 #endif

--- a/Tests/PerfTests.cc
+++ b/Tests/PerfTests.cc
@@ -27,9 +27,9 @@
 
 // Catch's REQUIRE is too slow for perf testing
 #undef REQUIRE
-#define REQUIRE(TEST)   while (!(TEST)) {abort();}
+#define REQUIRE(TEST)   do{ if (!(TEST)) abort();} while (false)
 #undef CHECK
-#define CHECK(TEST)     while (!(TEST)) {abort();}
+#define CHECK(TEST)     do{ if (!(TEST)) abort();} while (false)
 
 
 using namespace fleece;

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -4,7 +4,7 @@
 
 #include "XcodeWarnings.xcconfig"
 
-WARNING_CFLAGS = $(WARNING_CFLAGS) -Wno-unknown-warning-option -Wno-atomic-implicit-seq-cst  // ignore unknown warning flags
+WARNING_CFLAGS = $(WARNING_CFLAGS) -Wno-unknown-warning-option -Wno-atomic-implicit-seq-cst  -Wno-implicit-int-float-conversion
 CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = NO     // jsonsl calls strcpy
 CLANG_WARN_DOCUMENTATION_COMMENTS = NO
 CLANG_WARN__EXIT_TIME_DESTRUCTORS = NO


### PR DESCRIPTION
Every Clang release adds new warnings, which turn into errors in our `LITECORE_WARNINGS_HARDCORE` build setting (and sometimes in Xcode builds too.) Some warnings I've disabled in the config, some I've fixed in source like
- Unnecessary semicolons
- Initializing an enum with 0
- Unnecessary 'virtual' on methods in a final class
- Implicit fallthrough between switch cases
- Some implicit int/float comparisons, although there were a lot more and I had to suppress the warning in the end
- A weird one in SmallVectorBase.hh that warned that the MS ABI wouldn't pack bitfields properly unless I made them the same type
- Const string arrays not declared constexpr