### PR TITLE
Fix issue with duplicate signal entries in the list

### DIFF
--- a/Fleece/Support/Backtrace+signals-posix.cc
+++ b/Fleece/Support/Backtrace+signals-posix.cc
@@ -17,27 +17,32 @@ namespace fleece {
     using namespace std;
     using namespace signal_safe;
 
+    namespace {
+        template<typename T, size_t N>
+        consteval bool allUnique(const array<T, N>& arr) {
+            for (size_t i = 0; i < N; ++i)
+                for (size_t j = i + 1; j < N; ++j)
+                    if (arr[i] == arr[j]) return false;
+            return true;
+        }
+    }
+
     class BacktraceSignalHandlerPosix : public BacktraceSignalHandler {
       public:
-        static vector<int> signals() {
-            return {
-                    SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGIOT, SIGQUIT, SIGSEGV, SIGSYS, SIGTRAP, SIGXCPU, SIGXFSZ,
-#if defined(__APPLE__)
-                    SIGEMT,
-#endif
-            };
+        static struct sigaction defaultAction() {
+            struct sigaction sa{};
+            sigemptyset(&sa.sa_mask);
+            sa.sa_flags   = 0;
+            sa.sa_handler = SIG_DFL;
+            return sa;
         }
 
         static struct sigaction defaultActionFor(int signal) {
-            if ( default_actions().find(signal) == default_actions().end() ) {
-                struct sigaction sa{};
-                sigemptyset(&sa.sa_mask);
-                sa.sa_flags   = 0;
-                sa.sa_handler = SIG_DFL;
-                return sa;
-            } else {
-                return default_actions()[signal];
+            if ( !default_actions().contains(signal) ) {
+                return defaultAction();
             }
+
+            return default_actions()[signal];
         }
 
         BacktraceSignalHandlerPosix() {
@@ -51,13 +56,11 @@ namespace fleece {
                 sigaltstack(&ss, nullptr);
             }
 
-            auto signal_vector = signals();
-            for ( size_t i = 0; i < signal_vector.size(); ++i ) {
-                struct sigaction action;
-                memset(&action, 0, sizeof(action));
-                action.sa_flags = static_cast<int>(SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND);
+            for ( const int signal : signals) {
+                struct sigaction action{};
+                action.sa_flags = SA_SIGINFO | SA_ONSTACK | SA_NODEFER | SA_RESETHAND;
                 sigfillset(&action.sa_mask);
-                sigdelset(&action.sa_mask, signal_vector[i]);
+                sigdelset(&action.sa_mask, signal);
 #if defined(__clang__)
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wdisabled-macro-expansion"
@@ -68,8 +71,11 @@ namespace fleece {
 #endif
 
                 struct sigaction old_action;
-                sigaction(signal_vector[i], &action, &old_action);
-                default_actions()[signal_vector[i]] = old_action;
+                if ( int success = sigaction(signal, &action, &old_action); success == 0) {
+                    // Only chain back if we succeeded and are not already chained back
+                    // to ourselves
+                    default_actions()[signal] = old_action;
+                }
             }
         }
 
@@ -80,6 +86,19 @@ namespace fleece {
 
       private:
         unique_ptr<byte[]> _stack_content;
+
+#ifdef __APPLE__
+        static constexpr array<int, 11> signals = {
+#else
+        static constexpr array<int, 10> signals = {
+#endif
+                SIGABRT, SIGBUS, SIGFPE, SIGILL, SIGQUIT, SIGSEGV, SIGSYS, SIGTRAP, SIGXCPU, SIGXFSZ,
+#if defined(__APPLE__)
+                SIGEMT,
+#endif
+        };
+
+        static_assert(allUnique(signals), "Signals array contains duplicate entries");
 
         static unordered_map<int, struct sigaction>& default_actions() {
             static unordered_map<int, struct sigaction> da;

--- a/Fleece/Support/Backtrace+signals-posix.cc
+++ b/Fleece/Support/Backtrace+signals-posix.cc
@@ -39,11 +39,13 @@ namespace fleece {
         }
 
         static struct sigaction defaultActionFor(int signal) {
-            if ( !default_actions().contains(signal) ) {
+            const auto& actions = default_actions();
+            auto        it      = actions.find(signal);
+            if ( it == actions.end() ) {
                 return defaultAction();
             }
 
-            return default_actions()[signal];
+            return it->second;
         }
 
         BacktraceSignalHandlerPosix() {

--- a/Fleece/Support/Backtrace+signals-posix.cc
+++ b/Fleece/Support/Backtrace+signals-posix.cc
@@ -72,8 +72,7 @@ namespace fleece {
 
                 struct sigaction old_action;
                 if ( int success = sigaction(signal, &action, &old_action); success == 0) {
-                    // Only chain back if we succeeded and are not already chained back
-                    // to ourselves
+                    // Only chain back if we succeeded
                     default_actions()[signal] = old_action;
                 }
             }

--- a/Fleece/Support/Backtrace+signals-posix.cc
+++ b/Fleece/Support/Backtrace+signals-posix.cc
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include <sstream>
 #include <unordered_map>
+#include <array>
 #ifdef __APPLE__
 #    include <sys/ucontext.h>
 #else

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -394,14 +394,9 @@ TEST_CASE("Backtrace") {
 #ifdef DEBUG
 
 namespace test::backtrace {
-    static int* createInvalidRef() {
-        return nullptr;
-    }
-
     static void doBadThings() {
-        int* landline = createInvalidRef();
         // ReSharper disable once CppDFANullDereference
-        *landline = 0xdead;
+        raise(SIGABRT);
     }
     static void crashOnPurpose() {
         doBadThings();
@@ -412,6 +407,37 @@ TEST_CASE("Backtrace crash", "[.BacktraceManual]") {
     // Since this test crashes the process intentionally,
     // It will fail and require manual inspection of stderr
     test::backtrace::crashOnPurpose();
+}
+
+static struct sigaction previous{};
+static void sig_handler(int signo, siginfo_t* info, void* context) {
+    if (signo == SIGSEGV) {
+        write(STDERR_FILENO, "This message should be in stderr, and the backtrace should be below it.\n", 72);
+    }
+
+    if (previous.sa_flags != 0) {
+        sigaction(signo, &previous, nullptr);
+        raise(signo);
+    }
+}
+
+TEST_CASE("Backtrace crash with override", "[.BacktraceManual]") {
+    struct sigaction action{};
+    action.sa_flags = SA_SIGINFO | SA_NODEFER | SA_RESETHAND;
+    sigfillset(&action.sa_mask);
+    sigdelset(&action.sa_mask, SIGSEGV);
+#if defined(__clang__)
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdisabled-macro-expansion"
+#endif
+    action.sa_sigaction = &sig_handler;
+#if defined(__clang__)
+#    pragma clang diagnostic pop
+#endif
+
+    int success = sigaction(SIGSEGV, &action, &previous);
+    CHECK(success == 0);
+    raise(SIGSEGV);
 }
 #endif
 

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -416,10 +416,8 @@ static void sig_handler(int signo, siginfo_t* info, void* context) {
         write(STDERR_FILENO, "This message should be in stderr, and the backtrace should be below it.\n", 72);
     }
 
-    if (previous.sa_flags != 0) {
-        sigaction(signo, &previous, nullptr);
-        raise(signo);
-    }
+    sigaction(signo, &previous, nullptr);
+    raise(signo);
 }
 
 TEST_CASE("Backtrace crash with override", "[.BacktraceManual]") {

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -395,7 +395,6 @@ TEST_CASE("Backtrace") {
 
 namespace test::backtrace {
     static void doBadThings() {
-        // ReSharper disable once CppDFANullDereference
         raise(SIGABRT);
     }
     static void crashOnPurpose() {
@@ -408,6 +407,8 @@ TEST_CASE("Backtrace crash", "[.BacktraceManual]") {
     // It will fail and require manual inspection of stderr
     test::backtrace::crashOnPurpose();
 }
+
+#ifndef _MSC_VER
 
 static struct sigaction previous{};
 static void sig_handler(int signo, siginfo_t* info, void* context) {
@@ -439,6 +440,8 @@ TEST_CASE("Backtrace crash with override", "[.BacktraceManual]") {
     CHECK(success == 0);
     raise(SIGSEGV);
 }
+
+#endif
 #endif
 
 


### PR DESCRIPTION
SIGABRT and SIGIOT are the same signal on most platforms and this meant that the "previous" signal handler was getting registered correctly the first time, and then overwritten to the same function the second time causing an infinite loop.  This adds a static assert to ensure that all signals in the list are unique.  It also adds another test to make sure that other things that override the signal handler can still properly chain back.