### PR TITLE
CBL-8000: Some Query tests crash with SQLite 3.51.3 (#289)

### DIFF
--- a/Fleece/Core/Doc.cc
+++ b/Fleece/Core/Doc.cc
@@ -190,7 +190,7 @@ namespace fleece { namespace impl {
         if (!_unregistered.test_and_set()) {            // this is atomic
 #if DEBUG
             // Assert that the data hasn't been changed since I was created:
-            if (_data.size < 1e6 && _data.hash() != _dataHash)
+            if (!_dontValidate && _data.size < 1e6 && _data.hash() != _dataHash)
                 FleeceException::_throw(InternalError,
                     "Memory range (%p .. %p) was altered while Scope %p (sk=%p) was active. "
                     "This usually means the Scope's data was freed/invalidated before the Scope "

--- a/Fleece/Core/Doc.hh
+++ b/Fleece/Core/Doc.hh
@@ -49,6 +49,13 @@ namespace fleece { namespace impl {
         slice data() const FLPURE                      {return _data;}
         alloc_slice allocedData() const FLPURE         {return _alloced;}
 
+        void dontValidate() {
+#if DEBUG
+            // c.f. FleeceCursor::resetScope where we ask to skip validation.
+            _dontValidate = true;
+#endif
+        }
+
         SharedKeys* sharedKeys() const FLPURE          {return _sk;}
         slice externDestination() const FLPURE         {return _externDestination;}
 
@@ -78,6 +85,7 @@ namespace fleece { namespace impl {
         std::atomic_flag    _unregistered ATOMIC_FLAG_INIT; // False if registered in sMemoryMap
 #if DEBUG
         uint32_t            _dataHash;                  // hash of _data, for troubleshooting
+        bool                _dontValidate{false};       // the check on the hash can be omitted
 #endif
     protected:
         bool                _isDoc {false};             // True if I am a field of a Doc


### PR DESCRIPTION
This is motivated by CBL-7988 (Upgrade SQLite to 3.51.3)

In the case of FleeceCursor, the slice used by Scope may be altered in the process of SQLite's virtual tabel logic. We allow it to disable the checksum check.