### PR TITLE
Remove unused methods that fail to compile on Android

### DIFF
--- a/Fleece.xcodeproj/project.pbxproj
+++ b/Fleece.xcodeproj/project.pbxproj
@@ -203,6 +203,9 @@
 		27F666472017FE7C00A8ED31 /* TempArray.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27F666462017FE7C00A8ED31 /* TempArray.hh */; };
 		27FE87F31E53E43200C5CF3F /* JSONEncoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27FE87F11E53E43200C5CF3F /* JSONEncoder.cc */; };
 		27FE87F41E53E43200C5CF3F /* JSONEncoder.hh in Headers */ = {isa = PBXBuildFile; fileRef = 27FE87F21E53E43200C5CF3F /* JSONEncoder.hh */; };
+		422342E32FC579C200DAC424 /* Backtrace+capture-darwin.cc in Sources */ = {isa = PBXBuildFile; fileRef = 422342E22FC579C200DAC424 /* Backtrace+capture-darwin.cc */; };
+		422342E62FC579E000DAC424 /* Backtrace+capture-posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = 422342E52FC579E000DAC424 /* Backtrace+capture-posix.cc */; };
+		422342E82FC579EA00DAC424 /* Backtrace+signals-posix.cc in Sources */ = {isa = PBXBuildFile; fileRef = 422342E72FC579EA00DAC424 /* Backtrace+signals-posix.cc */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -487,6 +490,9 @@
 		27F666462017FE7C00A8ED31 /* TempArray.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = TempArray.hh; sourceTree = "<group>"; };
 		27FE87F11E53E43200C5CF3F /* JSONEncoder.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSONEncoder.cc; sourceTree = "<group>"; };
 		27FE87F21E53E43200C5CF3F /* JSONEncoder.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = JSONEncoder.hh; sourceTree = "<group>"; };
+		422342E22FC579C200DAC424 /* Backtrace+capture-darwin.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "Backtrace+capture-darwin.cc"; sourceTree = "<group>"; };
+		422342E52FC579E000DAC424 /* Backtrace+capture-posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "Backtrace+capture-posix.cc"; sourceTree = "<group>"; };
+		422342E72FC579EA00DAC424 /* Backtrace+signals-posix.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "Backtrace+signals-posix.cc"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -814,6 +820,9 @@
 			children = (
 				2700BBA0218B949900797537 /* Backtrace.hh */,
 				2700BBA1218B949900797537 /* Backtrace.cc */,
+				422342E22FC579C200DAC424 /* Backtrace+capture-darwin.cc */,
+				422342E52FC579E000DAC424 /* Backtrace+capture-posix.cc */,
+				422342E72FC579EA00DAC424 /* Backtrace+signals-posix.cc */,
 				273CD2D625E874CD00B93C59 /* Base64.hh */,
 				273CD2D725E874CD00B93C59 /* Base64.cc */,
 				2746DD3B1D931BE9000517BC /* Benchmark.hh */,
@@ -1426,6 +1435,7 @@
 				273CD2D925E874CD00B93C59 /* Base64.cc in Sources */,
 				27DE2EEB2125FC9300123597 /* FleeceException.cc in Sources */,
 				275B3596234BE12800FE9CF0 /* FLSlice.cc in Sources */,
+				422342E32FC579C200DAC424 /* Backtrace+capture-darwin.cc in Sources */,
 				27DE2E962125FA1700123597 /* RefCounted.cc in Sources */,
 				2700BBA3218B949900797537 /* Backtrace.cc in Sources */,
 				2718B3912CAF22F8006C09CB /* ConcurrentArena.cc in Sources */,
@@ -1433,12 +1443,14 @@
 				2779BA1124CB4A4900BCEA8F /* ConcurrentMap.cc in Sources */,
 				27DFAE13219F83AB00DF57EB /* InstanceCounted.cc in Sources */,
 				27DE2E9D2125FA1700123597 /* slice+CoreFoundation.cc in Sources */,
+				422342E82FC579EA00DAC424 /* Backtrace+signals-posix.cc in Sources */,
 				27D965692339595700F4A51C /* NumConversion.cc in Sources */,
 				27DE2EEA2125FC5A00123597 /* Writer.cc in Sources */,
 				275F0460261E46E9005261C0 /* slice_stream.cc in Sources */,
 				27DE2E922125FA1700123597 /* varint.cc in Sources */,
 				27DE2EE82125FB2100123597 /* cdecode.c in Sources */,
 				27DE2EE92125FB2100123597 /* cencode.c in Sources */,
+				422342E62FC579E000DAC424 /* Backtrace+capture-posix.cc in Sources */,
 				2700BB9D217E8C0D00797537 /* ParseDate.cc in Sources */,
 				27D9656E23397EF700F4A51C /* SwiftDtoa.cc in Sources */,
 			);

--- a/Fleece/Support/Backtrace+capture-linux.cc
+++ b/Fleece/Support/Backtrace+capture-linux.cc
@@ -5,8 +5,10 @@
 #include "Backtrace.hh"
 #include <dlfcn.h>   // dladdr()
 #include <unwind.h>  // part of compiler runtime, no extra link needed
-#include <backtrace.h>
 #include <mutex>
+#ifdef HAVE_LIBBACKTRACE
+#    include <backtrace.h>
+#endif
 #include <cstring>
 
 namespace fleece {
@@ -33,6 +35,7 @@ namespace fleece {
         return int(state.current - buffer);
     }
 
+#ifdef HAVE_LIBBACKTRACE
     static backtrace_state* getBacktraceState() {
         static std::once_flag   once;
         static backtrace_state* state;
@@ -73,6 +76,7 @@ namespace fleece {
                 nullptr, &info);
         return info;
     }
+#endif  // HAVE_LIBBACKTRACE
 
     Backtrace::frameInfo Backtrace::getFrame(const void* addr, bool stack_top) {
         Backtrace::frameInfo frame = {};
@@ -88,15 +92,15 @@ namespace fleece {
             if ( const char* slash = strrchr(frame.library, '/') ) frame.library = slash + 1;
         }
 
-#ifdef __ANDROID__
-        frame.function = info.dli_sname;
-        if ( info.dli_saddr )
-            frame.offset = reinterpret_cast<size_t>(frame.pc) - reinterpret_cast<size_t>(info.dli_saddr);
+#ifndef HAVE_LIBBACKTRACE
+        frame.function = dlInfo.dli_sname;
+        if ( dlInfo.dli_saddr )
+            frame.offset = reinterpret_cast<size_t>(frame.pc) - reinterpret_cast<size_t>(dlInfo.dli_saddr);
 
-        if ( info.dli_fbase ) {
+        if ( dlInfo.dli_fbase ) {
             auto pc = reinterpret_cast<uintptr_t>(frame.pc);
             if ( !stack_top ) pc -= 1;
-            frame.imageOffset = pc - reinterpret_cast<uintptr_t>(info.dli_fbase);
+            frame.imageOffset = pc - reinterpret_cast<uintptr_t>(dlInfo.dli_fbase);
         }
 #else
         uintptr_t pc = reinterpret_cast<uintptr_t>(frame.pc);
@@ -129,7 +133,7 @@ namespace fleece {
     }
 
     string FunctionName(const void* pc) {
-#if !defined(__ANDROID__)
+#ifdef HAVE_LIBBACKTRACE
         uintptr_t addr = reinterpret_cast<uintptr_t>(pc) - 1;
         if ( const char* name = backtraceResolve(addr).function ) return Unmangle(name);
         return {};

--- a/Fleece/Support/Backtrace+capture-posix.cc
+++ b/Fleece/Support/Backtrace+capture-posix.cc
@@ -11,6 +11,8 @@ namespace fleece {
     using namespace std;
     using namespace signal_safe;
 
+    char* unmangle(const char* function);
+
     static constexpr struct {
         const char *old, *nuu;
     } kAbbreviations[] = {

--- a/Fleece/Support/Backtrace+signals-posix.cc
+++ b/Fleece/Support/Backtrace+signals-posix.cc
@@ -10,6 +10,7 @@
 #include <array>
 #ifdef __APPLE__
 #    include <sys/ucontext.h>
+#    include "TargetConditionals.h"
 #else
 #    include <ucontext.h>
 #endif

--- a/Fleece/Support/Backtrace+signals-posix.cc
+++ b/Fleece/Support/Backtrace+signals-posix.cc
@@ -107,28 +107,6 @@ namespace fleece {
             return da;
         }
 
-        static string& violation_type() {
-            static string type;
-            return type;
-        }
-
-        static void* extract_pc(void* context) {
-            auto* uctx = static_cast<ucontext_t*>(context);
-#ifdef REG_RIP  // x86_64 Linux
-            return reinterpret_cast<void*>(uctx->uc_mcontext.gregs[REG_RIP]);
-#elif defined(__aarch64__)
-#    if defined(__APPLE__)
-            return reinterpret_cast<void*>(uctx->uc_mcontext->__ss.__pc);
-#    else
-            return reinterpret_cast<void*>(uctx->uc_mcontext.pc);
-#    endif
-#elif defined(__APPLE__) && defined(__x86_64__)
-            return reinterpret_cast<void*>(uctx->uc_mcontext->__ss.__rip);
-#else
-#    error "Unsupported architecture"
-#endif
-        }
-
         NOINLINE static void crash_handler_immediate(siginfo_t* info, void* context) {
             void*       buffer[50];
             int         n    = Backtrace::raw_capture(buffer, 50, context);

--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -91,7 +91,6 @@ namespace fleece {
         static void      handleTerminate(const std::function<void(const std::string&)>& logger);
         frameInfo        getFrame(unsigned) const;
         static frameInfo getFrame(const void* pc, bool stack_top);
-        static char*     unmangle(const char* function NONNULL);
 #endif
 
         std::vector<void*> _addrs;  // Array of PCs in backtrace, top first


### PR DESCRIPTION
Also fixes some iOS problems.  The files need to be added to the Xcode project and TargetConditionals.h needs to be included.