### PR TITLE
Fixed a compile error in AtomicRefCounted tests

### DIFF
--- a/Fleece/Support/RefCounted.cc
+++ b/Fleece/Support/RefCounted.cc
@@ -136,7 +136,7 @@ namespace fleece {
     namespace internal {
         /// Tag bit that's added to `_ref` while accessing it.
         /// We can't use the low bit (1) because mutable Fleece Values already use that as a tag.
-        static constexpr uintptr_t kBusyMask = uintptr_t(1) << 63;
+        static constexpr uintptr_t kBusyMask = uintptr_t(1) << (8 * sizeof(uintptr_t) - 1);
 
         AtomicWrapper::AtomicWrapper(uintptr_t ref) noexcept
         :_ref(ref)

--- a/Tests/SupportTests.cc
+++ b/Tests/SupportTests.cc
@@ -473,7 +473,7 @@ struct AtomicRetainedTest : RefCounted {
 
 TEST_CASE("AtomicRetained") {
     // This is mostly to check for compile errors.
-    AtomicRef r = new AtomicRetainedTest();
+    AtomicRef<AtomicRetainedTest> r = new AtomicRetainedTest();
     CHECK(r->i == 0);
     AtomicRetained r2 = r;
     AtomicRetained r3 = std::move(r2);


### PR DESCRIPTION
In LiteCore PR https://github.com/couchbase/couchbase-lite-core/pull/2503 the Ubuntu build failed with a GCC error building Fleece tests, in 
```
couchbase-lite-core/vendor/fleece/Tests/SupportTests.cc:476:15: error: alias template 'AtomicRef' requires template arguments; argument deduction only allowed for class templates
  476 |     AtomicRef r = new AtomicRetainedTest();
```
This is a regression introduced by #272 / #303 but it wasn't caught in Fleece's CI, apparently because Fleece's CI builds with GCC on Ubuntu, while LiteCore builds with Clang; and probably a different Clang than Fleece uses on macOS since it didn't get this error either.