### PR TITLE
CBL-8465: Don't store open file stream on Windows for crash log

### DIFF
--- a/Fleece/Support/Backtrace+signals-win32.cc
+++ b/Fleece/Support/Backtrace+signals-win32.cc
@@ -96,11 +96,14 @@ namespace fleece {
                 bt = Backtrace::capture(skip, 32 + skip);
             }
 
-            if ( sCrashStream ) {
-                sCrashStream << "\n\n******************** Process Crash: " << violation_type()
-                             << " ********************\n";
-                bt->writeTo(sCrashStream);
-                sCrashStream << "\n******************** Now terminating ********************\n";
+            if ( !sLogPath.empty() ) {
+                ofstream crashStream(sLogPath, ios::out | ios::trunc | ios::binary);
+                if ( crashStream ) {
+                    crashStream << "\n\n******************** Process Crash: " << violation_type()
+                                << " ********************\n";
+                    bt->writeTo(crashStream);
+                    crashStream << "\n******************** Now terminating ********************\n";
+                }
             }
 
             cerr << "\n\n******************** Process Crash: " << violation_type() << " ********************\n";
@@ -110,11 +113,9 @@ namespace fleece {
     };
 
     // Awkwardly defined here to avoid FleeceBase getting its own copy since it also compiles Backtrace.cc
-    ofstream BacktraceSignalHandler::sCrashStream;
+    string BacktraceSignalHandler::sLogPath;
 
-    void BacktraceSignalHandler::setLogPath(const char* path) {
-        sCrashStream = ofstream(path, ios::out | ios::trunc | ios::binary);
-    }
+    void BacktraceSignalHandler::setLogPath(const char* path) { sLogPath = path; }
 }  // namespace fleece
 
 static fleece::BacktraceSignalHandlerWin32 handler;

--- a/Fleece/Support/Backtrace.hh
+++ b/Fleece/Support/Backtrace.hh
@@ -39,7 +39,7 @@ namespace fleece {
 
       protected:
 #ifdef _WIN32
-        static std::ofstream sCrashStream;
+        static std::string sLogPath;
 #else
         static volatile sig_atomic_t sLogFD;
 #endif


### PR DESCRIPTION
This causes any attempt to delete the directory to fail because the file is in use.  Windows exception handlers are not nearly as demanding on POSIX signal handlers, so the need to pre-open a file stream does not exist anyway.  Just open it when the exception happens instead